### PR TITLE
Pit mode switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ luac.out
 *.x86_64
 *.hex
 
+install.bat

--- a/Horus.lua
+++ b/Horus.lua
@@ -70,7 +70,7 @@ backgroundFill = TEXT_BGCOLOR
 foregroundColor = LINE_COLOR
 globalTextOptions = TEXT_COLOR
 
-local run_ui = assert(loadScript("/SCRIPTS/BF/ui.lua"))()
+local run_ui, background_ui = assert(loadScript("/SCRIPTS/BF/ui.lua"))()
 
 drawScreenTitle = function (title)
   lcd.drawFilledRectangle(0, 0, LCD_W, 30, TITLE_BGCOLOR)
@@ -78,4 +78,4 @@ drawScreenTitle = function (title)
   --lcd.drawText(LCD_W-40, 5, page.."/"..pages, MENU_TITLE_COLOR)
 end
 
-return {run=run_ui}
+return {run=run_ui, background=background_ui}

--- a/X7.lua
+++ b/X7.lua
@@ -69,5 +69,5 @@ MenuBox = { x=1, y=10, w=100, x_offset=36, h_line=10, h_offset=3 }
 SaveBox = { x=20, y=12, w=100, x_offset=4,  h=30, h_offset=5 }
 NoTelem = { 36, 55, "No Telemetry", BLINK }
 
-local run_ui = assert(loadScript("/SCRIPTS/BF/ui.lua"))()
-return {run=run_ui}
+local run_ui, background_ui = assert(loadScript("/SCRIPTS/BF/ui.lua"))()
+return {run=run_ui, background=background_ui}

--- a/X9.lua
+++ b/X9.lua
@@ -69,5 +69,5 @@ MenuBox = { x=40, y=12, w=120, x_offset=36, h_line=8, h_offset=3 }
 SaveBox = { x=40, y=12, w=120, x_offset=4,  h=30, h_offset=5 }
 NoTelem = { 70, 55, "No Telemetry", BLINK }
 
-local run_ui = assert(loadScript("/SCRIPTS/BF/ui.lua"))()
-return {run=run_ui}
+local run_ui, background_ui = assert(loadScript("/SCRIPTS/BF/ui.lua"))()
+return {run=run_ui, background=background_ui}

--- a/functions/pm_arm.lua
+++ b/functions/pm_arm.lua
@@ -1,0 +1,7 @@
+local function run()
+  if gPitModeState and gPitModeState == PIT_MODE_STATE_DISARMED then
+    gPitModeState = PIT_MODE_STATE_ARMED
+  end
+end
+
+return { run=run }

--- a/functions/pm_d-arm.lua
+++ b/functions/pm_d-arm.lua
@@ -1,0 +1,7 @@
+local function run()
+  if gPitModeState then
+    gPitModeState = PIT_MODE_STATE_DISARMED
+  end
+end
+
+return { run=run }


### PR DESCRIPTION
Hey, first off, forgive me if I am not doing this correctly.  While I'm a software engineer, I don't have any experience with git or it's workflow :D. 

This code lets you disable pit mode with a switch through telemetry.  It has some safety features built in.  It also does not require that the telemetry screen is visible.

You need to assign the pm_arm and pm_d-arm functions to different positions of a switch.  In order for pit mode to be deactivated, (armed) the function pm_d-arm first has to run, followed by pm_arm.   This allows some safety such that you can't just power up your quad with the video arming switch enabled and start transmitting, you must first first hit the disarmed state.

Next, I added a background task and refactored the telemetry communication stuff to that so the switch can be used with the telemetry screen closed.
