### PR TITLE
Added a 4th screen to control the Camera's OSD.

### DIFF
--- a/Horus.lua
+++ b/Horus.lua
@@ -59,6 +59,19 @@ SetupPages = {
          { t = "Dev",     x = 240, y = 68, sp = 68, i=1, ro=true, table = {[3]="SmartAudio",[4]="Tramp",[255]="None"} },
          { t = "Freq",    x = 240, y = 96, sp = 68, i="f", ro=true },
       },
+   },
+   -- TODO fix the alignment
+   {
+      title = "Camera OSD control",
+      text = {
+         { t = "MENU", x = 86, y = 16 },
+         { t = "EXIT", x = 87, y = 40 },
+         { t = "+", x = 121, y = 28 },
+         { t = "-", x = 68, y = 28 },
+         { t = "ENT", x = 89, y = 28 },
+         { t = "(Hold MENU to exit page)", x = 36, y = 54 }
+      },
+      fields = {},
    }
 }
 

--- a/X7.lua
+++ b/X7.lua
@@ -62,7 +62,21 @@ SetupPages = {
          { t = "Dev",  x = 60, y = 12, sp = 34, i=1, ro=true, table = {[3]="SA",[4]="Tramp",[255]="None"} },
          { t = "Freq", x = 60, y = 22, sp = 34, i="f", ro=true },
       },
+   },
+   -- TODO fix the alignment
+   {
+      title = "Camera OSD control",
+      text = {
+         { t = "MENU", x = 86, y = 16 },
+         { t = "EXIT", x = 87, y = 40 },
+         { t = "+", x = 121, y = 28 },
+         { t = "-", x = 68, y = 28 },
+         { t = "ENT", x = 89, y = 28 },
+         { t = "(Hold MENU to exit page)", x = 36, y = 54 }
+      },
+      fields = {},
    }
+
 }
 
 MenuBox = { x=1, y=10, w=100, x_offset=36, h_line=10, h_offset=3 }

--- a/X9.lua
+++ b/X9.lua
@@ -62,6 +62,18 @@ SetupPages = {
          { t = "Dev",     x = 100, y = 14, sp = 32, i=1, ro=true, table = {[3]="SmartAudio",[4]="Tramp",[255]="None"} },
          { t = "Freq",    x = 100, y = 24, sp = 32, i="f", ro=true },
       },
+   },
+   {
+      title = "Camera OSD control",
+      text = {
+         { t = "MENU", x = 86, y = 16 },
+         { t = "EXIT", x = 87, y = 40 },
+         { t = "+", x = 121, y = 28 },
+         { t = "-", x = 68, y = 28 },
+         { t = "ENT", x = 89, y = 28 },
+         { t = "(Hold MENU to exit page)", x = 36, y = 54 }
+      },
+      fields = {},
    }
 }
 

--- a/common/bf_cam.lua
+++ b/common/bf_cam.lua
@@ -1,0 +1,60 @@
+assert(loadScript("/SCRIPTS/BF/bf_msp.lua"))()
+assert(loadScript("/SCRIPTS/BF/util.lua"))()
+
+--- a table of MSP camera OSD commands.
+CAM_OSD_COMMANDS = {
+   ENTER = 0,
+   LEFT = 1,
+   UP = 2,
+   RIGHT = 3,
+   DOWN = 4
+}
+
+--- @return a table of supported key press commands to MSP camera OSD commands.
+local function initializeCamOsdCommandValuesTable()
+   table = {}
+
+   -- right
+   addToTableIfKeyNotNil(table, EVT_PLUS_FIRST, CAM_OSD_COMMANDS.RIGHT)       -- Taranis
+   addToTableIfKeyNotNil(table, EVT_PLUS_REPT, CAM_OSD_COMMANDS.RIGHT)        -- Horus
+   addToTableIfKeyNotNil(table, EVT_ROT_RIGHT, CAM_OSD_COMMANDS.RIGHT)        -- Horus
+   -- left
+   addToTableIfKeyNotNil(table, EVT_MINUS_FIRST, CAM_OSD_COMMANDS.LEFT)       -- Taranis
+   addToTableIfKeyNotNil(table, EVT_MINUS_REPT, CAM_OSD_COMMANDS.LEFT)        -- Taranis
+   addToTableIfKeyNotNil(table, EVT_ROT_LEFT, CAM_OSD_COMMANDS.LEFT)          -- Horus
+   -- down
+   addToTableIfKeyNotNil(table, EVT_EXIT_BREAK, CAM_OSD_COMMANDS.DOWN)
+   -- up
+   addToTableIfKeyNotNil(table, EVT_MENU_BREAK, CAM_OSD_COMMANDS.UP)          -- Taranis
+   -- enter
+   addToTableIfKeyNotNil(table, EVT_ENTER_BREAK, CAM_OSD_COMMANDS.ENTER)
+
+   return table
+end
+
+--- Key press to MSP camera OSD command translation table
+local keyPressesToCamOsdCommands = initializeCamOsdCommandValuesTable()
+
+--- Sends the given MSP camera OSD command via Smartport, if it's not nil.
+-- @return whether the given command was sent.
+local function sendCamOsdCommand(value)
+   if (value ~= nil) then
+      return mspSendRequest(BF_MSP_COMMANDS.MSP_CAMERA_CONTROL, {value})
+   else
+      return false
+   end
+end
+
+--- Handles the given key press, by looking up the corresponding OSD command, if any.
+-- Unhandled key presses will always return "false".
+-- @return whether the command was handled, and a MSP camera OSD command sent as a result of the given event
+function handleCamOsdKeypress(event)
+   osdCommand = keyPressesToCamOsdCommands[event]
+   if (osdCommand ~= nil) then
+--      print("sendCamOsdCommand: ", event, osdCommand)
+      sendCamOsdCommand(osdCommand)
+      return true;
+   else
+      return false;
+   end
+end

--- a/common/bf_msp.lua
+++ b/common/bf_msp.lua
@@ -1,0 +1,21 @@
+--- BF MSP commands, see msp/msp_protocol.h in Betaflight
+BF_MSP_COMMANDS = {
+   -- getter
+   MSP_RC_TUNING = 111,
+   MSP_PID = 112,
+
+   -- setter
+   MSP_SET_PID = 202,
+   MSP_SET_RC_TUNING = 204,
+
+   -- BF specials
+   MSP_PID_ADVANCED = 94,
+   MSP_SET_PID_ADVANCED = 95,
+   MSP_VTX_CONFIG = 88,
+   MSP_VTX_SET_CONFIG = 89,
+
+   -- camera OSD control
+   MSP_CAMERA_CONTROL = 98,
+
+   MSP_EEPROM_WRITE = 250
+}

--- a/common/util.lua
+++ b/common/util.lua
@@ -1,0 +1,57 @@
+function clipValue(val, min, max)
+   if val < min then
+      val = min
+   elseif val > max then
+      val = max
+   end
+
+   return val
+end
+
+
+local lastDebugPrintText = ""
+
+--- For debugging: Draws the last logged string to the screen at a predefined location.
+function drawLastDebugPrintText()
+   if (lastDebugPrintText ~= nil) then
+      lcd.drawText(10, 56, lastDebugPrintText, SMLSIZE)
+   end
+end
+
+--- For debugging: Logs the given string to the console, as well as stores it and draws it on-screen.
+-- @param str 
+function debugPrint(str)
+   print(str)
+   lastDebugPrintText = str
+   drawLastDebugPrintText(str)
+end
+
+--- Adds the given value at the given index if the index is not nil, to the given table.
+-- @param table
+-- @param key table key, if nil, will not be added
+-- @param value
+--
+function addToTableIfKeyNotNil(table, key, value)
+--   print("Table", key, value)
+   if (key ~= nil) then
+      table[key] = value
+   end
+end
+
+--- The time that the last menu LONG keypress was handled
+local lastHandledMenuLong = 0
+
+--- For how long to ignore EVT_MENU_BREAK after a handled EVT_MENU_LONG, in 10ms ticks
+local IGNORE_MENU_BREAK_AFTER_MENU_LONG_DURATION = 1000 / 10 -- 1000 millis is 1000 "10ms ticks"
+
+--- @return whether an EVT_MENU_BREAK should be ignored since an EVT_MENU_LONG was recently handled.
+function shouldIgnoreMenuBreak()
+   return getTime() - lastHandledMenuLong < IGNORE_MENU_BREAK_AFTER_MENU_LONG_DURATION
+end
+
+--- Records that EVT_MENU_LONG was just handled.
+function handledMenuLong()
+   lastHandledMenuLong = getTime()
+end
+
+


### PR DESCRIPTION
The PR depends on [this PR in the BF repo](https://github.com/betaflight/betaflight/pull/2727) which enables Camera OSD control.

Extracted the MSP constants into bf_msp.
Note: The 4th screen UI alignment is correct for the X9 but needs to be adjusted for a Horus or the X7.

See https://github.com/betaflight/betaflight/issues/2613 

**Note: This is currently untested (although it works fine in the Simulator), so there's no need to merge it until it's tested.** Feel free to review the code and make suggestions, I only learned LUA a few days ago.