### PR TITLE
Made vtx freq editable

### DIFF
--- a/Horus.lua
+++ b/Horus.lua
@@ -1,3 +1,6 @@
+G_MIN_FREQ_VAL = 5000
+G_MAX_FREQ_VAL = 5999
+
 SetupPages = {
    {
       title = "PIDs",
@@ -51,13 +54,13 @@ SetupPages = {
       title = "VTX",
       text = {},
       fields = {
-         -- Super Rate
-         { t = "Band",    x = 35,  y = 68, sp = 94, i=2, min=1, max=5, table = { "A", "B", "E", "F", "R" } },
+         -- VTX Settings
+         { t = "Band",    x = 35,  y = 68, sp = 94, i=2, min=0, max=5, table = { [0]="U", "A", "B", "E", "F", "R" } },
          { t = "Channel", x = 35,  y = 96, sp = 94, i=3, min=1, max=8 },
          { t = "Power",   x = 35,  y = 124, sp = 94, i=4, min=1 },
          { t = "Pit",     x = 35,  y = 152, sp = 94, i=5, min=0, max=1, table = { [0]="OFF", "ON" } },
          { t = "Dev",     x = 240, y = 68, sp = 68, i=1, ro=true, table = {[3]="SmartAudio",[4]="Tramp",[255]="None"} },
-         { t = "Freq",    x = 240, y = 96, sp = 68, i="f", ro=true },
+         { t = "Freq",    x = 240, y = 96, sp = 68, i="f", min=G_MIN_FREQ_VAL, max=G_MAX_FREQ_VAL },
       },
    }
 }

--- a/X7.lua
+++ b/X7.lua
@@ -1,3 +1,6 @@
+G_MIN_FREQ_VAL = 5000
+G_MAX_FREQ_VAL = 5999
+
 SetupPages = {
    {
       title = "PIDs",
@@ -54,13 +57,13 @@ SetupPages = {
       title = "VTX",
       text = {},
       fields = {
-         -- Super Rate
-         { t = "Band", x = 1, y = 12, sp = 34, i=2, min=1, max=5, table = { "A", "B", "E", "F", "R" } },
+         -- VTX Settings
+         { t = "Band", x = 1, y = 12, sp = 34, i=2, min=0, max=5, table = { [0]="U", "A", "B", "E", "F", "R" } },
          { t = "Ch",   x = 1, y = 22, sp = 34, i=3, min=1, max=8 },
          { t = "Pw",   x = 1, y = 32, sp = 34, i=4, min=1 },
          { t = "Pit",  x = 1, y = 42, sp = 34, i=5, min=0, max=1, table = { [0]="OFF", "ON" } },
          { t = "Dev",  x = 60, y = 12, sp = 34, i=1, ro=true, table = {[3]="SA",[4]="Tramp",[255]="None"} },
-         { t = "Freq", x = 60, y = 22, sp = 34, i="f", ro=true },
+         { t = "Freq", x = 60, y = 22, sp = 34, i="f", min=G_MIN_FREQ_VAL, max=G_MAX_FREQ_VAL },
       },
    }
 }

--- a/X9.lua
+++ b/X9.lua
@@ -1,3 +1,6 @@
+G_MIN_FREQ_VAL = 5000
+G_MAX_FREQ_VAL = 5999
+
 SetupPages = {
    {
       title = "PIDs",
@@ -54,13 +57,13 @@ SetupPages = {
       title = "VTX",
       text = {},
       fields = {
-         -- Super Rate
-         { t = "Band",    x = 25,  y = 14, sp = 50, i=2, min=1, max=5, table = { "A", "B", "E", "F", "R" } },
+         -- VTX Settings
+         { t = "Band",    x = 25,  y = 14, sp = 50, i=2, min=0, max=5, table = { [0]="U", "A", "B", "E", "F", "R" } },
          { t = "Channel", x = 25,  y = 24, sp = 50, i=3, min=1, max=8 },
          { t = "Power",   x = 25,  y = 34, sp = 50, i=4, min=1 },
          { t = "Pit",     x = 25,  y = 44, sp = 50, i=5, min=0, max=1, table = { [0]="OFF", "ON" } },
          { t = "Dev",     x = 100, y = 14, sp = 32, i=1, ro=true, table = {[3]="SmartAudio",[4]="Tramp",[255]="None"} },
-         { t = "Freq",    x = 100, y = 24, sp = 32, i="f", ro=true },
+         { t = "Freq",    x = 100, y = 24, sp = 32, i="f", min=G_MIN_FREQ_VAL, max=G_MAX_FREQ_VAL },
       },
    }
 }

--- a/common/msp_sp.lua
+++ b/common/msp_sp.lua
@@ -239,6 +239,10 @@ function mspPollReply()
    return nil
 end
 
+function mspGetLastReqValue()
+   return mspLastReq
+end
+
 --
 -- End of MSP/SPORT code
 --

--- a/common/ui.lua
+++ b/common/ui.lua
@@ -25,6 +25,9 @@ local EDITING      = 3
 local PAGE_SAVING  = 4
 local MENU_DISP    = 5
 
+local NUM_BANDS = 5
+local NUM_CHANS = 8
+
 local gState = PAGE_DISPLAY
 
 local currentPage = 1
@@ -382,8 +385,101 @@ local freqLookup = {
     { 5658, 5695, 5732, 5769, 5806, 5843, 5880, 5917 }, -- RaceBand
 }
 
+local lastFreqVal = 0
+local lastFreqUpdTS = 0
+local freqModCntr = 0
+
+local function updateVTXBandChan(page)
+   if page.values[2] > 0 then   -- band != 0
+      page.values["f"] = freqLookup[page.values[2]][page.values[3]]
+   else   -- band == 0; set freq via channel*100
+      page.values["f"] = 5100 + (math.floor(page.values[3]) * 100)
+   end
+  lastFreqVal = page.values["f"]   -- keep track of displayed freq
+end
+
 local function updateVTXFreq(page)
-   page.values["f"] = freqLookup[page.values[2]][page.values[3]]
+   local newFreq = page.values["f"]
+   if page.values[2] == 0 then   -- band == 0
+      local now = getTime()   -- track rate of change for possible mod speedup
+      if newFreq ~= lastFreqVal and now < lastFreqUpdTS + 15 then
+         freqModCntr = freqModCntr + (15-(lastFreqUpdTS-now))   -- increase counter for mod speedup
+      else
+         freqModCntr = 0   -- no mod speedup
+      end
+      if freqModCntr > 65 then  -- rate is fast enough; do mod speedup
+         if newFreq > lastFreqVal then
+            newFreq = clipValue(newFreq + math.floor(freqModCntr/65), G_MIN_FREQ_VAL, G_MAX_FREQ_VAL)
+         else
+            newFreq = clipValue(newFreq - math.floor(freqModCntr/65), G_MIN_FREQ_VAL, G_MAX_FREQ_VAL)
+         end
+         page.values["f"] = newFreq
+      end
+                        -- set channel value via freq/100:
+      page.values[3] = clipValue(math.floor((newFreq - 5100) / 100), 1, 8)
+      lastFreqUpdTS = now
+      lastFreqVal = newFreq            -- keep track of displayed freq
+   else   -- band != 0; find closest freq in table that is above/below dialed freq
+      if newFreq ~= lastFreqVal then
+         local startBand
+         local endBand
+         local incFlag       -- freq increasing or decreasing
+         if newFreq > lastFreqVal then
+            incFlag = 1
+            startBand = 1
+            endBand = NUM_BANDS
+         else
+            incFlag = -1
+            startBand = NUM_BANDS
+            endBand = 1
+         end
+         local curBand = page.values[2]
+         local curChan = page.values[3]
+         local selBand = 0
+         local selChan = 0
+         local selFreq = 0
+         local diffVal = 9999
+         local fVal
+              -- need to scan bands in same "direction" as 'incFlag'
+              --  so same-freq selections will be handled properly (F8 & R7)
+         for band=startBand,endBand,incFlag do
+            for chan=1,NUM_CHANS do
+               if band ~= curBand or chan ~= curChan then   -- don't reselect same band/chan
+                  fVal = freqLookup[band][chan]
+                  if incFlag > 0 then
+                     if fVal >= lastFreqVal and fVal - lastFreqVal < diffVal then
+                             -- if same freq then only select if "next" band:
+                        if fVal ~= lastFreqVal or band > curBand then
+                           selBand = band
+                           selChan = chan
+                           selFreq = fVal
+                           diffVal = fVal - lastFreqVal
+                        end
+                     end
+                  else
+                     if fVal <= lastFreqVal and lastFreqVal - fVal < diffVal then
+                             -- if same freq then only select if "previous" band:
+                        if fVal ~= lastFreqVal or band < curBand then
+                           selBand = band
+                           selChan = chan
+                           selFreq = fVal
+                           diffVal = lastFreqVal - fVal
+                        end
+                     end
+                  end
+               end
+            end
+         end
+         if selFreq > 0 then
+            page.values["f"] = selFreq      -- using new freq from table
+            page.values[2] = selBand
+            page.values[3] = selChan
+            lastFreqVal = selFreq           -- keep track of displayed freq
+         else
+            page.values["f"] = lastFreqVal  -- if no match then revert freq
+         end
+      end
+   end
 end
 
 local function postReadVTX(page)
@@ -399,17 +495,42 @@ local function postReadVTX(page)
    end
 
 
-   if page.values and page.values[2] and page.values[3] then
-      if page.values[2] > 0 and page.values[3] > 0 then
-         updateVTXFreq(page)
+   if page.values then
+      local rfreq
+      if page.values[7] and page.values[7] > 0 then
+         rfreq = page.values[6] + (page.values[7] * 256)
       else
-         page.values = nil
+         rfreq = 0
+      end
+      if page.values[2] and page.values[2] > 0 then   -- band != 0
+         if page.values[3] and page.values[3] > 0 then
+            updateVTXBandChan(page)
+            if rfreq == 0 then            -- if user freq not supported then
+               page.fields[1].min = 1     -- don't allow 'U' band
+            end
+         else
+            page.values = nil
+         end
+      else   -- band == 0
+         if rfreq > 0 then
+            page.values["f"] = rfreq
+            lastFreqVal = rfreq           -- keep track of displayed freq
+            updateVTXFreq(page)
+            page.fields[1].min = 0        -- make sure 'U' band allowed
+         else
+            page.values = nil
+         end
       end
    end
 end
 
 local function getWriteValuesVTX(values)
-   local channel = (values[2]-1)*8 + values[3]-1
+   local channel
+   if values[2] > 0 then   -- band != 0
+      channel = (values[2]-1)*8 + values[3]-1
+   else   -- band == 0
+      channel = values["f"]
+   end
    return { bit32.band(channel,0xFF), bit32.rshift(channel,8), values[4], values[5] }
 end
 
@@ -426,7 +547,8 @@ SetupPages[3].getWriteValues = getWriteValuesVTX
 SetupPages[3].saveMaxRetries = 0
 SetupPages[3].saveTimeout    = 300 -- 3s
 
-SetupPages[3].fields[1].upd = updateVTXFreq
-SetupPages[3].fields[2].upd = updateVTXFreq
+SetupPages[3].fields[1].upd = updateVTXBandChan
+SetupPages[3].fields[2].upd = updateVTXBandChan
+SetupPages[3].fields[6].upd = updateVTXFreq
 
 return run_ui


### PR DESCRIPTION
(Note updated PR #92)

Can step through available frequencies for bands / channels.  Implements feature suggested by issue #33.

If Cleanflight/Betaflight has 'SetFreqByMHzMsp' support then any frequency in MHz can be set when the band is set to 'U'.  (The channel field may be used to set the frequency in 100-MHz increments.)

For 'SetFreqByMHzMsp' test builds and documentation, see:  http://www.etheli.com/CF/vtxCfgCMSFreqViaMsp

Betaflght PR:  https://github.com/betaflight/betaflight/pull/4265

--ET