### PR TITLE
Syncing date and time to BF with MSP over SmartPort

### DIFF
--- a/X7.lua
+++ b/X7.lua
@@ -1,3 +1,6 @@
+-- load msp.lua
+assert(loadScript("/SCRIPTS/BF/msp_sp.lua"))()
+
 SetupPages = {
    {
       title = "PIDs",
@@ -69,5 +72,103 @@ MenuBox = { x=1, y=10, w=100, x_offset=36, h_line=10, h_offset=3 }
 SaveBox = { x=20, y=12, w=100, x_offset=4,  h=30, h_offset=5 }
 NoTelem = { 36, 55, "No Telemetry", BLINK }
 
+-- ---------------------------------------
+-- BACKGROUND PROCESS
+-- ---------------------------------------
+
+local INTERVAL          = 100        -- 100 = 1 second, 200 = 2 seconds, ...
+local MSP_SET_RTC       = 246
+local MSP_TX_INFO       = 186
+local sensorName        = "VFAS"
+
+local lastRunTS
+local oldSensorValue
+local sensorId
+local mspMsgQueued = false
+
+local function getTelemetryId(name)
+    local field = getFieldInfo(name)
+    if field then
+      return field['id']
+    else
+      return -1
+    end
+end
+
+local function init()
+    sensorId = getTelemetryId(sensorName)
+    oldSensorValue = 0
+    lastRunTS = 0
+end
+
+local function run_bg()
+
+    -- run in intervals
+    if lastRunTS == 0 or lastRunTS + INTERVAL < getTime() then
+
+        mspMsgQueued = false
+
+        -- ------------------------------------
+        -- SYNC DATE AND TIME
+        -- ------------------------------------
+
+        -- get sensor value
+        local newSensorValue = getValue(sensorId)
+
+        if type(newSensorValue) == "number" then
+
+            -- Send datetime when the telemetry connection is available
+            -- assuming when sensor value higher than 0 there is an telemetry connection
+            -- only send datetime one time after telemetry connection became available 
+            -- or when connection is restored after e.g. lipo refresh
+            if oldSensorValue == 0 and newSensorValue > 0 then
+                local now = getDateTime()
+                local year = now.year;
+
+                values = {}
+                values[1] = bit32.band(year, 0xFF)
+                year = bit32.rshift(year, 8)
+                values[2] = bit32.band(year, 0xFF)
+                values[3] = now.mon
+                values[4] = now.day
+                values[5] = now.hour
+                values[6] = now.min
+                values[7] = now.sec
+
+                -- send msp message
+                mspSendRequest(MSP_SET_RTC, values)
+                mspMsgQueued = true
+            end
+
+            oldSensorValue = newSensorValue
+        end
+
+
+        -- ------------------------------------
+        -- SEND RSSI VALUE
+        -- ------------------------------------
+
+        if mspMsgQueued == false then
+            local rssi, alarm_low, alarm_crit = getRSSI()
+            values = {}
+            values[1] = rssi
+
+            -- send msp message
+            mspSendRequest(MSP_TX_INFO, values)
+            mspMsgQueued = true
+        end
+
+        lastRunTS = getTime()
+    end
+
+    -- process queue
+    mspProcessTxQ()
+
+end
+
+--
+-- END
+--
+
 local run_ui = assert(loadScript("/SCRIPTS/BF/ui.lua"))()
-return {run=run_ui}
+return { init=init, run=run_ui, background=run_bg }

--- a/X9.lua
+++ b/X9.lua
@@ -1,3 +1,7 @@
+-- load msp.lua
+assert(loadScript("/SCRIPTS/BF/msp_sp.lua"))()
+
+-- pages
 SetupPages = {
    {
       title = "PIDs",
@@ -69,5 +73,36 @@ MenuBox = { x=40, y=12, w=120, x_offset=36, h_line=8, h_offset=3 }
 SaveBox = { x=40, y=12, w=120, x_offset=4,  h=30, h_offset=5 }
 NoTelem = { 70, 55, "No Telemetry", BLINK }
 
+--
+-- THIS CODE HAS TO BE MOVED TO A SEPERATE LUA FILE
+--
+
+local MSP_SET_TX_INFO      = 187
+
+--
+
+local INTERVAL = 200        -- 100 = 1 second, 200 = 2 seconds, ...
+local lastSendTS = 0
+
+local function run_bg()
+
+    if lastSendTS == 0 or lastSendTS + INTERVAL < getTime() then
+        local now = getDateTime()
+        local values = { now.year-2000, now.mon, now.day, now.hour, now.min, now.sec, getRSSI().rssi }
+
+        -- send info
+        mspSendRequest(MSP_SET_TX_INFO, values)
+
+        playNumber(getTime(), 0, 0)
+
+        lastSendTS = getTime()
+    end
+
+end
+
+--
+-- END
+--
+
 local run_ui = assert(loadScript("/SCRIPTS/BF/ui.lua"))()
-return {run=run_ui}
+return { run=run_ui, background=run_bg }

--- a/X9.lua
+++ b/X9.lua
@@ -77,7 +77,7 @@ NoTelem = { 70, 55, "No Telemetry", BLINK }
 -- THIS CODE HAS TO BE MOVED TO A SEPERATE LUA FILE
 --
 
-local MSP_SET_TX_INFO      = 187
+local MSP_SET_RTC      = 246
 
 --
 
@@ -89,10 +89,20 @@ local function run_bg()
     if lastSendTS == 0 or lastSendTS + INTERVAL < getTime() then
         local now = getDateTime()
         local rssi, alarm_low, alarm_high = getRSSI()
-        local values = { now.year-2000, now.mon, now.day, now.hour, now.min, now.sec, rssi }
+        local year = now.year;
+
+        local values = {}
+        values[1] = bit32.band(year, 0xFF)
+        year = bit32.rshift(year, 8)
+        values[2] = bit32.band(year, 0xFF)
+        values[3] = now.mon
+        values[4] = now.day
+        values[5] = now.hour
+        values[6] = now.min
+        values[7] = now.sec
 
         -- send info
-        mspSendRequest(MSP_SET_TX_INFO, values)
+        mspSendRequest(MSP_SET_RTC, values)
 
         lastSendTS = getTime()
     end

--- a/X9.lua
+++ b/X9.lua
@@ -88,15 +88,16 @@ local function run_bg()
 
     if lastSendTS == 0 or lastSendTS + INTERVAL < getTime() then
         local now = getDateTime()
-        local values = { now.year-2000, now.mon, now.day, now.hour, now.min, now.sec, getRSSI().rssi }
+        local rssi, alarm_low, alarm_high = getRSSI()
+        local values = { now.year-2000, now.mon, now.day, now.hour, now.min, now.sec, rssi }
 
         -- send info
         mspSendRequest(MSP_SET_TX_INFO, values)
 
-        playNumber(getTime(), 0, 0)
-
         lastSendTS = getTime()
     end
+
+    mspProcessTxQ()
 
 end
 

--- a/common/ui.lua
+++ b/common/ui.lua
@@ -1,6 +1,3 @@
--- load msp.lua
-assert(loadScript("/SCRIPTS/BF/msp_sp.lua"))()
-
 -- getter
 local MSP_RC_TUNING     = 111
 local MSP_PID           = 112


### PR DESCRIPTION
Send current datetime from OpenTX to BF with MSP over SmartPort.
Datetime is only send one time after telemetry connector became available/restored.
As tested it doesn't effect the BF LUA menu script.

Needs corresponding FW changes: https://github.com/betaflight/betaflight/pull/4289