### PR TITLE
Add 'Retrying' popup, etc

### DIFF
--- a/common/msp_sp.lua
+++ b/common/msp_sp.lua
@@ -239,6 +239,10 @@ function mspPollReply()
    return nil
 end
 
+function mspGetLastReqValue()
+   return mspLastReq
+end
+
 --
 -- End of MSP/SPORT code
 --


### PR DESCRIPTION
Shows 'Retrying' if save-retry happens.  Fixed 'processMspReply()' handing of case where EEPROM_WRITE not done.  Made general timeout 3 seconds and changed VTX-page 'saveMaxRetries' from 0 to 1.  Added 'mspGetLastReqValue()' fn to 'msp_sp.lua'.

I'm seeing issues with the reliability of the save-page command and response.  With the new code for the 'Retrying' message in place you can see when the transaction fails and repeats.  Without this, and with shorter timeouts (and no retries on VTX page) I think these transaction failures have been less noticeable.

The background thread doing extra calls to 'mspSendRequest()' makes it worse, as these can interfere with the transactions in "ui.lua".  I think there needs to be some kind of flagging or queuing.  But even with an older version of the scripts (i.e., [here](https://github.com/ethomas997/betaflight-tx-lua-scripts/tree/v0.41)) I still see retries happening all the time.  My test setup is Taranis X7, XSR receiver, BF 'master' as of 2017-11-11.

I left some comment-out code at the end of 'run_ui()' that may be useful for debugging.

--ET