### PR TITLE
Make vtx freq editable (rebased)

### DIFF
--- a/Horus.lua
+++ b/Horus.lua
@@ -1,3 +1,6 @@
+G_MIN_FREQ_VAL = 5000
+G_MAX_FREQ_VAL = 5999
+
 SetupPages = {
    {
       title = "PIDs",
@@ -51,13 +54,13 @@ SetupPages = {
       title = "VTX",
       text = {},
       fields = {
-         -- Super Rate
-         { t = "Band",    x = 35,  y = 68, sp = 94, i=2, min=1, max=5, table = { "A", "B", "E", "F", "R" } },
+         -- VTX Settings
+         { t = "Band",    x = 35,  y = 68, sp = 94, i=2, min=0, max=5, table = { [0]="U", "A", "B", "E", "F", "R" } },
          { t = "Channel", x = 35,  y = 96, sp = 94, i=3, min=1, max=8 },
          { t = "Power",   x = 35,  y = 124, sp = 94, i=4, min=1 },
          { t = "Pit",     x = 35,  y = 152, sp = 94, i=5, min=0, max=1, table = { [0]="OFF", "ON" } },
          { t = "Dev",     x = 240, y = 68, sp = 68, i=1, ro=true, table = {[3]="SmartAudio",[4]="Tramp",[255]="None"} },
-         { t = "Freq",    x = 240, y = 96, sp = 68, i="f", ro=true },
+         { t = "Freq",    x = 240, y = 96, sp = 68, i="f", min=G_MIN_FREQ_VAL, max=G_MAX_FREQ_VAL },
       },
    }
 }

--- a/X7.lua
+++ b/X7.lua
@@ -1,3 +1,6 @@
+G_MIN_FREQ_VAL = 5000
+G_MAX_FREQ_VAL = 5999
+
 SetupPages = {
    {
       title = "PIDs",
@@ -54,13 +57,13 @@ SetupPages = {
       title = "VTX",
       text = {},
       fields = {
-         -- Super Rate
-         { t = "Band", x = 1, y = 12, sp = 34, i=2, min=1, max=5, table = { "A", "B", "E", "F", "R" } },
+         -- VTX Settings
+         { t = "Band", x = 1, y = 12, sp = 34, i=2, min=0, max=5, table = { [0]="U", "A", "B", "E", "F", "R" } },
          { t = "Ch",   x = 1, y = 22, sp = 34, i=3, min=1, max=8 },
          { t = "Pw",   x = 1, y = 32, sp = 34, i=4, min=1 },
          { t = "Pit",  x = 1, y = 42, sp = 34, i=5, min=0, max=1, table = { [0]="OFF", "ON" } },
          { t = "Dev",  x = 60, y = 12, sp = 34, i=1, ro=true, table = {[3]="SA",[4]="Tramp",[255]="None"} },
-         { t = "Freq", x = 60, y = 22, sp = 34, i="f", ro=true },
+         { t = "Freq", x = 60, y = 22, sp = 34, i="f", min=G_MIN_FREQ_VAL, max=G_MAX_FREQ_VAL },
       },
    }
 }

--- a/X9.lua
+++ b/X9.lua
@@ -1,4 +1,8 @@
 -- pages
+
+G_MIN_FREQ_VAL = 5000
+G_MAX_FREQ_VAL = 5999
+
 SetupPages = {
    {
       title = "PIDs",
@@ -55,13 +59,13 @@ SetupPages = {
       title = "VTX",
       text = {},
       fields = {
-         -- Super Rate
-         { t = "Band",    x = 25,  y = 14, sp = 50, i=2, min=1, max=5, table = { "A", "B", "E", "F", "R" } },
+         -- VTX Settings
+         { t = "Band",    x = 25,  y = 14, sp = 50, i=2, min=0, max=5, table = { [0]="U", "A", "B", "E", "F", "R" } },
          { t = "Channel", x = 25,  y = 24, sp = 50, i=3, min=1, max=8 },
          { t = "Power",   x = 25,  y = 34, sp = 50, i=4, min=1 },
          { t = "Pit",     x = 25,  y = 44, sp = 50, i=5, min=0, max=1, table = { [0]="OFF", "ON" } },
          { t = "Dev",     x = 100, y = 14, sp = 32, i=1, ro=true, table = {[3]="SmartAudio",[4]="Tramp",[255]="None"} },
-         { t = "Freq",    x = 100, y = 24, sp = 32, i="f", ro=true },
+         { t = "Freq",    x = 100, y = 24, sp = 32, i="f", min=G_MIN_FREQ_VAL, max=G_MAX_FREQ_VAL },
       },
    }
 }

--- a/common/msp_sp.lua
+++ b/common/msp_sp.lua
@@ -239,6 +239,10 @@ function mspPollReply()
    return nil
 end
 
+function mspGetLastReqValue()
+   return mspLastReq
+end
+
 --
 -- End of MSP/SPORT code
 --


### PR DESCRIPTION
This adds the functionality in PR #41, rebased to the current 'master'.

Can step through available frequencies for bands / channels.  Implements feature suggested by issue #33.

If Cleanflight/Betaflight has 'SetFreqByMHzMsp' support then any frequency in MHz can be set when the band is set to 'U'.  (The channel field may be used to set the frequency in 100-MHz increments.)  The current Betaflight 'master' supports this functionality.

This also includes the changes in PR #56 . (Note save-page issues described in that PR.)

For 'SetFreqByMHzMsp' documentation, see:  http://www.etheli.com/CF/vtxCfgCMSFreqViaMsp

--ET