### PR TITLE
Updated radios to include low resolution settings

### DIFF
--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -10,17 +10,20 @@ local supportedRadios =
     ["x7"] =
     {
         templateHome    = SCRIPT_HOME.."/X7/",
-        preLoad         = SCRIPT_HOME.."/X7/x7pre.lua"
+        preLoad         = SCRIPT_HOME.."/X7/x7pre.lua",
+        resolution      = lcdResolution.low
     },
     ["x9d"] =
     {
         templateHome    = SCRIPT_HOME.."/X9/",
-        preLoad         = SCRIPT_HOME.."/X9/x9pre.lua"
+        preLoad         = SCRIPT_HOME.."/X9/x9pre.lua",
+        resolution      = lcdResolution.low
     },
     ["x9d+"] =
     {
         templateHome    = SCRIPT_HOME.."/X9/",
-        preLoad         = SCRIPT_HOME.."/X9/x9pre.lua"
+        preLoad         = SCRIPT_HOME.."/X9/x9pre.lua",
+        resolution      = lcdResolution.low
     },
     ["x10"] =
     {


### PR DESCRIPTION
Added lcdResolution.low designation for low-res radios (x7 and x9)