### PR TITLE
Suppressing sending of RSSI in background while in menu.

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash 
 
 if [ -d obj ]; then
-    rm -fR obj
+    rm -fR obj/*
 fi
 
-cp -fR src obj
+cp -fR src/* obj
 
 MANIFEST=(`find obj/ -name *.lua -type f`);
 

--- a/src/SCRIPTS/TELEMETRY/bf.lua
+++ b/src/SCRIPTS/TELEMETRY/bf.lua
@@ -7,6 +7,23 @@ assert(loadScript(radio.preLoad))()
 assert(loadScript(protocol.transport))()
 assert(loadScript(SCRIPT_HOME.."/MSP/common.lua"))()
 
-local run = assert(loadScript(SCRIPT_HOME.."/ui.lua"))()
+local run_ui = assert(loadScript(SCRIPT_HOME.."/ui.lua"))()
+local background = assert(loadScript(SCRIPT_HOME.."/background.lua"))()
 
-return { run=run }
+local MENU_TIMESLICE = 100
+
+local lastMenuEvent = 0
+
+function run(event)
+  lastMenuEvent = getTime()
+
+  run_ui(event)
+end
+
+function run_bg()
+  if lastMenuEvent + MENU_TIMESLICE < getTime() then
+    background.run_bg()
+  end
+end
+
+return { init=background.init, run=run, background=run_bg }


### PR DESCRIPTION
This stops the RSSI transmission from slowing down the MSP commands that load the config for the menu.

Also, reinstating the background task, must have been lost in the transition.

Plus stopped deleting the `obj/` directory on build, to be able to keep it open in a file manager while testing.