### PR TITLE
"Soft" reverting the background function

### DIFF
--- a/src/SCRIPTS/TELEMETRY/bf.lua
+++ b/src/SCRIPTS/TELEMETRY/bf.lua
@@ -26,4 +26,5 @@ function run_bg()
   end
 end
 
-return { init=background.init, run=run, background=run_bg }
+--return { init=background.init, run=run, background=run_bg }
+return { run=run_ui }


### PR DESCRIPTION
Using a comment to "soft" revert the background function. I, as well as a few other users, have found that it seems to be preventing access to the telemetry buffer.