### PR TITLE
Background functions disabled for Crossfire, as they are specific to SmartPort

### DIFF
--- a/src/SCRIPTS/BF/protocols.lua
+++ b/src/SCRIPTS/BF/protocols.lua
@@ -2,6 +2,7 @@ local supportedProtocols =
 {
     smartPort =
     {
+        name            = "SmartPort",
         transport       = SCRIPT_HOME.."/MSP/sp.lua",
         rssi            = function() return getValue("RSSI") end,
         exitFunc        = function() return 0 end,
@@ -13,6 +14,7 @@ local supportedProtocols =
     },
     crsf =
     {
+        name            = "Crossfire",
         transport       = SCRIPT_HOME.."/MSP/crsf.lua",
         rssi            = function() return getValue("TQly") end,
         exitFunc        = function() return "/CROSSFIRE/crossfire.lua" end,

--- a/src/SCRIPTS/TELEMETRY/bf.lua
+++ b/src/SCRIPTS/TELEMETRY/bf.lua
@@ -26,5 +26,8 @@ function run_bg()
   end
 end
 
---return { init=background.init, run=run, background=run_bg }
-return { run=run_ui }
+if protocol.name == "SmartPort" then
+    return { init=background.init, run=run, background=run_bg }
+else
+    return { run=run_ui }
+end


### PR DESCRIPTION
Background functions do not handle frames in a way that is compatible with Crossfire.  Will issue a reworked PR including this fix.  May require changes to Betaflight telemetry code for CRSF.