### PR TITLE
Fix invalid index error on the result of getFieldInfo in background.lua

### DIFF
--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -9,7 +9,10 @@ local mspMsgQueued = false
 
 local function getSensorValue()
     if sensorId == -1 then
-        sensorId = getFieldInfo(protocol.stateSensor)['id'] or -1
+        local sensor = getFieldInfo(protocol.stateSensor)
+        if type(sensor) == "table" then
+            sensorId = sensor['id'] or -1
+        end
     end
     return getValue(sensorId)
 end


### PR DESCRIPTION
This fix attempts to address the invalid index issue encountered in background.lua (line 12 error).