### PR TITLE
Updated screens to support u16 version of dtermSetpointWeight

### DIFF
--- a/src/SCRIPTS/BF/HORUS/rates2.lua
+++ b/src/SCRIPTS/BF/HORUS/rates2.lua
@@ -6,6 +6,7 @@ return {
    reboot         = false,
    eepromWrite    = true,
    minBytes       = 23,
+   outputBytes    = 23,
    text = {
       { t = "Anti-Gravity",       x =  28, y =  62 },
       { t = "Gain",               x =  38, y = 100 },

--- a/src/SCRIPTS/BF/X7/rates3.lua
+++ b/src/SCRIPTS/BF/X7/rates3.lua
@@ -6,6 +6,7 @@ return {
    reboot         = false,
    eepromWrite    = true,
    minBytes       = 23,
+   outputBytes    = 23,
    text = {
       { t = "Anti-Grav Gain", x = 15, y = 17, to = SMLSIZE },
       { t = "Anti-Grav Thr",  x = 15, y = 30, to = SMLSIZE },

--- a/src/SCRIPTS/BF/X7/rates4.lua
+++ b/src/SCRIPTS/BF/X7/rates4.lua
@@ -6,6 +6,7 @@ return {
    reboot         = false,
    eepromWrite    = true,
    minBytes       = 23,
+   outputBytes    = 23,
    text = {
       { t = "Dterm Setpoint", x = 28, y = 15, to = SMLSIZE },
       { t = "Weight", x = 33, y = 28, to = SMLSIZE },

--- a/src/SCRIPTS/BF/X9/rates2.lua
+++ b/src/SCRIPTS/BF/X9/rates2.lua
@@ -6,6 +6,7 @@ return {
    reboot         = false,
    eepromWrite    = true,
    minBytes       = 23,
+   outputBytes    = 23,
    text = {
       { t = "Anti-Gravity", x = 35, y = 13, to = SMLSIZE },
       { t = "Gain", x = 15, y = 23, to = SMLSIZE },

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -32,6 +32,7 @@ Page = nil
 
 backgroundFill = backgroundFill or ERASE
 foregroundColor = foregroundColor or SOLID
+
 globalTextOptions = globalTextOptions or 0
 
 local function saveSettings(new)
@@ -39,7 +40,10 @@ local function saveSettings(new)
         if Page.preSave then
             payload = Page.preSave(Page)
         else
-            payload = Page.values
+            payload = {}
+            for i=1,(Page.outputBytes or #Page.values) do
+                payload[i] = Page.values[i]
+            end
         end
         protocol.mspWrite(Page.write, payload)
         saveTS = getTime()


### PR DESCRIPTION
Corrects issue where dtermSetpointWeight cannot be updated due to data type change in the MSP definition in 3.4.