### PR TITLE
Change setting of RTC to use ticks.

### DIFF
--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -42,6 +42,7 @@ local function run_bg()
             -- or when connection is restored after e.g. lipo refresh
 
             if API_VERSION < 1.041 then
+                -- format: year (16) / month (8) / day (8) / hour (8) / min (8) / sec (8)
                 local now = getDateTime()
                 local year = now.year;
 
@@ -55,16 +56,16 @@ local function run_bg()
                 values[6] = now.min
                 values[7] = now.sec
             else
+                -- format: seconds after the epoch (32) / milliseconds (16)
                 local now = getRtcTime()
 
                 values = {}
-                values[1] = bit32.band(now, 0xFF)
-                now = bit32.rshift(now, 8)
-                values[2] = bit32.band(now, 0xFF)
-                now = bit32.rshift(now, 8)
-                values[3] = bit32.band(now, 0xFF)
-                now = bit32.rshift(now, 8)
-                values[4] = bit32.band(now, 0xFF)
+
+                for i = 1, 4 do
+                    values[i] = bit32.band(now, 0xFF)
+                    now = bit32.rshift(now, 8)
+                end
+
                 values[5] = 0 -- we don't have milliseconds
                 values[6] = 0
             end

--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -40,6 +40,8 @@ local function run_bg()
             -- assuming when sensor value higher than 0 there is an telemetry connection
             -- only send datetime one time after telemetry connection became available
             -- or when connection is restored after e.g. lipo refresh
+
+            --[[ Uncomment for firmware versions before 4.0:
             local now = getDateTime()
             local year = now.year;
 
@@ -52,6 +54,21 @@ local function run_bg()
             values[5] = now.hour
             values[6] = now.min
             values[7] = now.sec
+            ]]
+
+            --[[ Uncomment for firmware versions 4.0 and up:]]
+            local now = getRtcTime()
+
+            values = {}
+            values[1] = bit32.band(now, 0xFF)
+            now = bit32.rshift(now, 8)
+            values[2] = bit32.band(now, 0xFF)
+            now = bit32.rshift(now, 8)
+            values[3] = bit32.band(now, 0xFF)
+            now = bit32.rshift(now, 8)
+            values[4] = bit32.band(now, 0xFF)
+            values[5] = 0 -- we don't have milliseconds
+            values[6] = 0
 
             -- send msp message
             protocol.mspWrite(MSP_SET_RTC, values)

--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -41,34 +41,33 @@ local function run_bg()
             -- only send datetime one time after telemetry connection became available
             -- or when connection is restored after e.g. lipo refresh
 
-            --[[ Uncomment for firmware versions before 4.0:
-            local now = getDateTime()
-            local year = now.year;
+            if API_VERSION < 1.041 then
+                local now = getDateTime()
+                local year = now.year;
 
-            values = {}
-            values[1] = bit32.band(year, 0xFF)
-            year = bit32.rshift(year, 8)
-            values[2] = bit32.band(year, 0xFF)
-            values[3] = now.mon
-            values[4] = now.day
-            values[5] = now.hour
-            values[6] = now.min
-            values[7] = now.sec
-            ]]
+                values = {}
+                values[1] = bit32.band(year, 0xFF)
+                year = bit32.rshift(year, 8)
+                values[2] = bit32.band(year, 0xFF)
+                values[3] = now.mon
+                values[4] = now.day
+                values[5] = now.hour
+                values[6] = now.min
+                values[7] = now.sec
+            else
+                local now = getRtcTime()
 
-            --[[ Uncomment for firmware versions 4.0 and up:]]
-            local now = getRtcTime()
-
-            values = {}
-            values[1] = bit32.band(now, 0xFF)
-            now = bit32.rshift(now, 8)
-            values[2] = bit32.band(now, 0xFF)
-            now = bit32.rshift(now, 8)
-            values[3] = bit32.band(now, 0xFF)
-            now = bit32.rshift(now, 8)
-            values[4] = bit32.band(now, 0xFF)
-            values[5] = 0 -- we don't have milliseconds
-            values[6] = 0
+                values = {}
+                values[1] = bit32.band(now, 0xFF)
+                now = bit32.rshift(now, 8)
+                values[2] = bit32.band(now, 0xFF)
+                now = bit32.rshift(now, 8)
+                values[3] = bit32.band(now, 0xFF)
+                now = bit32.rshift(now, 8)
+                values[4] = bit32.band(now, 0xFF)
+                values[5] = 0 -- we don't have milliseconds
+                values[6] = 0
+            end
 
             -- send msp message
             protocol.mspWrite(MSP_SET_RTC, values)

--- a/src/SCRIPTS/TELEMETRY/bf.lua
+++ b/src/SCRIPTS/TELEMETRY/bf.lua
@@ -7,7 +7,7 @@ SCRIPT_HOME = "/SCRIPTS/BF"
 -- Version mapping:
 --  1.041: Betaflight 4.0 and newer
 -- <1.041: Betaflight 3.5 and older
-API_VERSION = 1.041
+API_VERSION = 1.040
 
 protocol = assert(loadScript(SCRIPT_HOME.."/protocols.lua"))()
 radio = assert(loadScript(SCRIPT_HOME.."/radios.lua"))()

--- a/src/SCRIPTS/TELEMETRY/bf.lua
+++ b/src/SCRIPTS/TELEMETRY/bf.lua
@@ -1,5 +1,14 @@
 SCRIPT_HOME = "/SCRIPTS/BF"
 
+-- Change this to match the API version of the firmware you are using
+-- (you can have multiple copies of this script with different values
+-- for API_VERSION, and select different versions for different models
+-- on your TX)
+-- Version mapping:
+--  1.041: Betaflight 4.0 and newer
+-- <1.041: Betaflight 3.5 and older
+API_VERSION = 1.041
+
 protocol = assert(loadScript(SCRIPT_HOME.."/protocols.lua"))()
 radio = assert(loadScript(SCRIPT_HOME.."/radios.lua"))()
 


### PR DESCRIPTION
To go with betaflight/betaflight#4682. Due to the dependency on this it will only work with firmware 4.0 and up, unfortunately. I do not know how to best deal with this, except allowing the user to change it by un-/commenting the relevant sections of code - supporting multiple API versions like it is done in configurator seems to be overly complex for the lua scripts.

Fixes betaflight/betaflight#6504.

