### PR TITLE
Disable VTX Power and Pit fields, when device type is unknown

### DIFF
--- a/src/SCRIPTS/BF/HORUS/vtx.lua
+++ b/src/SCRIPTS/BF/HORUS/vtx.lua
@@ -202,6 +202,12 @@ return {
             elseif self.values[1] == 4 then      -- Tramp
                 self.fields[3].table = { 25, 100, 200, 400, 600 }
                 self.fields[3].max = 5
+            elseif self.values[1] == 255 then    -- None/Unknown
+                self.fields[3].t = nil       -- don't display Power field
+                self.fields[3].max = 1
+                self.fields[3].table = { [1]="" }
+                self.fields[4].t = nil       -- don't display Pit field
+                self.fields[4].table = { [0]="", "" }
             end
         end
     end,

--- a/src/SCRIPTS/BF/X7/vtx.lua
+++ b/src/SCRIPTS/BF/X7/vtx.lua
@@ -181,6 +181,12 @@ return {
             elseif self.values[1] == 4 then      -- Tramp
                 self.fields[3].table = { 25, 100, 200, 400, 600 }
                 self.fields[3].max = 5
+            elseif self.values[1] == 255 then    -- None/Unknown
+                self.fields[3].t = nil       -- don't display Power field
+                self.fields[3].max = 1
+                self.fields[3].table = { [1]="" }
+                self.fields[4].t = nil       -- don't display Pit field
+                self.fields[4].table = { [0]="", "" }
             end
         end
     end,

--- a/src/SCRIPTS/BF/X9/vtx.lua
+++ b/src/SCRIPTS/BF/X9/vtx.lua
@@ -181,6 +181,12 @@ return {
             elseif self.values[1] == 4 then      -- Tramp
                 self.fields[3].table = { 25, 100, 200, 400, 600 }
                 self.fields[3].max = 5
+            elseif self.values[1] == 255 then    -- None/Unknown
+                self.fields[3].t = nil       -- don't display Power field
+                self.fields[3].max = 1
+                self.fields[3].table = { [1]="" }
+                self.fields[4].t = nil       -- don't display Pit field
+                self.fields[4].table = { [0]="", "" }
             end
         end
     end,


### PR DESCRIPTION
If the type of VTX is unknown, the power field (table) is not fully initialized. This results in an exception when unintentionally entering the power field.

This change disables power and pit fields, if the VTX device is unknown. Band and channel should remain functional, because the VTX could be connected to another device (PDB/OSD) (see https://github.com/betaflight/betaflight/pull/6522).