### PR TITLE
Fix for unable to update gyro lowpass. 

### DIFF
--- a/src/SCRIPTS/BF/HORUS/filters.lua
+++ b/src/SCRIPTS/BF/HORUS/filters.lua
@@ -6,6 +6,7 @@ return {
     reboot            = false,
     title             = "Filters",
     minBytes          = 18,
+    outputBytes       = 18,
     text= {
         -- Column headers
         { t = "Gy LP",         x = 60,  y = 68, to = SMLSIZE },

--- a/src/SCRIPTS/BF/X7/filters1.lua
+++ b/src/SCRIPTS/BF/X7/filters1.lua
@@ -6,6 +6,7 @@ return {
     reboot            = false,
     title             = "Filt (1/2)",
     minBytes          = 18,
+    outputBytes       = 18,
     text= {
         { t = "LPF", x = 43, y = 14, to = SMLSIZE },
         { t = "Gyro", x = 20, y = 24, to = SMLSIZE },

--- a/src/SCRIPTS/BF/X9/filters.lua
+++ b/src/SCRIPTS/BF/X9/filters.lua
@@ -6,6 +6,7 @@ return {
     reboot            = false,
     title             = "Filters",
     minBytes          = 18,
+    outputBytes       = 18,
     text= {
         { t = "LPF", x = 43, y = 14, to = SMLSIZE },
         { t = "Gyro", x = 15, y = 24, to = SMLSIZE },


### PR DESCRIPTION
When trying to update the gyro lowpass filter the value is set to it's original value when saving. 

This is because https://github.com/betaflight/betaflight/blob/793c5f7b71db746146a086e5c667759a0f13d415/src/main/interface/msp.c#L1248 contains TWO sbufWriteU8(dst, gyroConfig()->gyro_lowpass_hz);.

When sending the data from the lua script, the modified value is set here: https://github.com/betaflight/betaflight/blob/793c5f7b71db746146a086e5c667759a0f13d415/src/main/interface/msp.c#L1814

And the original value is set here: https://github.com/betaflight/betaflight/blob/793c5f7b71db746146a086e5c667759a0f13d415/src/main/interface/msp.c#L1833 overwriting the modified value. 

Sending only 18 bytes back prevents betaflight from entering that last if-statement. 

This is my first pull request. Hope i did it right.

