### PR TITLE
Increase smartport save timeout

### DIFF
--- a/src/SCRIPTS/BF/protocols.lua
+++ b/src/SCRIPTS/BF/protocols.lua
@@ -10,7 +10,7 @@ local supportedProtocols =
         maxTxBufferSize = 6,
         maxRxBufferSize = 6,
         saveMaxRetries  = 2,
-        saveTimeout     = 300
+        saveTimeout     = 500
     },
     crsf =
     {


### PR DESCRIPTION
Increase smartport save timeout from 3 to 5 seconds. Increases the chances of saving on the first try with FPORT. Testing shows that very often it takes just a little over 3 seconds before the ``eepromWrite`` command is received back from the FC when using FPORT. If it doesn't arrive within 5 seconds, i think we can safely assume that it isn't coming at all and try again. 

The downside is that if it does fail to save, we have to wait a few seconds longer, but i think 5 seconds is a good compromise.