### PR TITLE
Round value when updating vals

### DIFF
--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -232,10 +232,11 @@ local function incValue(inc)
     local f = Page.fields[currentLine]
     local idx = f.i or currentLine
     local scale = (f.scale or 1)
-    f.value = clipValue(f.value + ((inc*(f.mult or 1))/scale), (f.min/scale) or 0, (f.max/scale) or 255)
-    f.value = math.floor((f.value*scale)/(f.mult or 1) + 0.5)/(scale/(f.mult or 1))
+    local mult = (f.mult or 1)
+    f.value = clipValue(f.value + ((inc*mult)/scale), (f.min/scale) or 0, (f.max/scale) or 255)
+    f.value = math.floor((f.value*scale)/mult + 0.5)/(scale/mult)
     for idx=1, #(f.vals) do
-        Page.values[f.vals[idx]] = bit32.rshift(f.value * scale, (idx-1)*8)
+        Page.values[f.vals[idx]] = bit32.rshift(math.floor(f.value*scale + 0.5), (idx-1)*8)
     end
     if f.upd and Page.values then
         f.upd(Page)


### PR DESCRIPTION
Found that in some cases it's not enough to just round ``f.value``. For example when setting rc rate to 2.05 and saving i would get 2.04 back. When updating ``vals``, errors seem to be multiplied when doing ``f.value*scale``, so it should be rounded there too. 

Also gave ``f.mult or 1`` its own variable since ``f.scale or 1`` already has one. 