### PR TITLE
Add D Min

### DIFF
--- a/src/SCRIPTS/BF/HORUS/pids2.lua
+++ b/src/SCRIPTS/BF/HORUS/pids2.lua
@@ -1,27 +1,44 @@
 
 return {
-   read           = 94, -- MSP_PID_ADVANCED
-   write          = 95, -- MSP_SET_PID_ADVANCED
-   title          = "PIDs (2/2)",
-   reboot         = false,
-   eepromWrite    = true,
-   minBytes       = 38,
-   text = {
-      { t = "Feed",       x =  135,  y = 52 },
-      { t = "forward",    x =  120,  y = 70 },
-      { t = "Transition", x =  250,  y = 150 },
-      { t = "ROLL",       x =  28,   y = 100 },
-      { t = "PITCH",      x =  28,   y = 150 },
-      { t = "YAW",        x =  28,   y = 200 },
-   },
-   fields = {
-      --   ROLL FF
-      { x =  140, y = 100, min = 0, max = 200, vals = { 33, 34 }, to = MIDSIZE },
-      --   PITCH FF
-      { x =  140, y = 150, min = 0, max = 200, vals = { 35, 36 }, to = MIDSIZE },
-      --   YAW FF
-      { x =  140, y = 200, min = 0, max = 200, vals = { 37, 38 }, to = MIDSIZE },
-      --   TRANSITION
-      { x =  350, y = 150, min = 0, max = 100, vals = { 9 },      to = MIDSIZE, scale = 100 },
-   },
+    read           = 94, -- MSP_PID_ADVANCED
+    write          = 95, -- MSP_SET_PID_ADVANCED
+    title          = "PIDs (2/2)",
+    reboot         = false,
+    eepromWrite    = true,
+    minBytes       = 44,
+    text = {
+        { t = "Feed",        x = 97,  y = 52 },
+        { t = "forward",     x = 82,  y = 70 },
+        { t = "D",           x = 207, y = 52 },
+        { t = "Min",         x = 202, y = 70 },
+        { t = "ROLL",        x = 28,  y = 100 },
+        { t = "PITCH",       x = 28,  y = 150 },
+        { t = "YAW",         x = 28,  y = 200 },
+
+        { t = "Feedforward", x = 290, y = 100 },
+        { t = "Transition",  x = 300, y = 120, to = SMLSIZE },
+        { t = "D Min",       x = 290, y = 140 },
+        { t = "Gain",        x = 300, y = 160, to = SMLSIZE },
+        { t = "Advance",     x = 300, y = 180, to = SMLSIZE },
+    },
+    fields = {
+        -- ROLL FF
+        { x = 102, y = 100, min = 0, max = 2000, vals = { 33, 34 }, to = MIDSIZE },
+        -- PITCH FF
+        { x = 102, y = 150, min = 0, max = 2000, vals = { 35, 36 }, to = MIDSIZE },
+        -- YAW FF
+        { x = 102, y = 200, min = 0, max = 2000, vals = { 37, 38 }, to = MIDSIZE },
+        -- ROLL D MIN
+        { x = 202, y = 100, min = 0, max = 100,  vals = { 40 },     to = MIDSIZE },
+        -- PITCH D MIN
+        { x = 202, y = 150, min = 0, max = 100,  vals = { 41 },     to = MIDSIZE },
+        -- YAW D MIN
+        { x = 202, y = 200, min = 0, max = 100,  vals = { 42 },     to = MIDSIZE },
+        -- FF TRANSITION
+        { x = 390, y = 120, min = 0, max = 100,  vals = { 9 }, scale = 100 },
+        -- D MIN GAIN
+        { x = 390, y = 160, min = 0, max = 100,  vals = { 43 } },
+        -- D MIN ADVANCE
+        { x = 390, y = 180, min = 0, max = 200,  vals = { 44 } },
+    },
 }

--- a/src/SCRIPTS/BF/X7/pids2.lua
+++ b/src/SCRIPTS/BF/X7/pids2.lua
@@ -1,27 +1,46 @@
 
 return {
-   read           = 94, -- MSP_PID_ADVANCED
-   write          = 95, -- MSP_SET_PID_ADVANCED
-   title          = "PIDs (2/2)",
-   reboot         = false,
-   eepromWrite    = true,
-   minBytes       = 38,
-   text = {
-      { t = "Feed",    x =  45,  y = 11, to=SMLSIZE },
-      { t = "forward", x =  37,  y = 18, to=SMLSIZE },
-      { t = "Transn",  x =  86,  y = 31, to=SMLSIZE },
-      { t = "ROLL",    x =  10,  y = 26, to=SMLSIZE },
-      { t = "PITCH",   x =  10,  y = 36, to=SMLSIZE },
-      { t = "YAW",     x =  10,  y = 46, to=SMLSIZE },
-   },
-   fields = {
-      --   ROLL FF
-      { x =  48, y = 26, min = 0, max = 200, vals = { 33, 34 }, to=SMLSIZE },
-      --   PITCH FF
-      { x =  48, y = 36, min = 0, max = 200, vals = { 35, 36 }, to=SMLSIZE },
-      --   YAW FF
-      { x =  48, y = 46, min = 0, max = 200, vals = { 37, 38 }, to=SMLSIZE },
-      -- TRANSITION
-      { x =  94, y = 40, min = 0, max = 100, vals = { 9 },      to=SMLSIZE, scale = 100 },
-   },
+    read           = 94, -- MSP_PID_ADVANCED
+    write          = 95, -- MSP_SET_PID_ADVANCED
+    title          = "PIDs (2/2)",
+    reboot         = false,
+    eepromWrite    = true,
+    minBytes       = 44,
+    yMinLimit      = 11,
+    yMaxLimit      = 52,
+    text = {
+        { t = "Feed",        x = 45,  y = 11, to = SMLSIZE },
+        { t = "forward",     x = 37,  y = 18, to = SMLSIZE },
+        { t = "D",           x = 85,  y = 11, to = SMLSIZE },
+        { t = "Min",         x = 80,  y = 18, to = SMLSIZE },
+        { t = "ROLL",        x = 10,  y = 26, to = SMLSIZE },
+        { t = "PITCH",       x = 10,  y = 36, to = SMLSIZE },
+        { t = "YAW",         x = 10,  y = 46, to = SMLSIZE },
+        
+        { t = "Feedforward", x = 10,  y = 60, to = SMLSIZE },
+        { t = "Transition",  x = 20,  y = 68, to = SMLSIZE },
+        { t = "D Min",       x = 10,  y = 76, to = SMLSIZE },
+        { t = "Gain",        x = 20,  y = 84, to = SMLSIZE },
+        { t = "Advance",     x = 20,  y = 92, to = SMLSIZE },
+    },
+    fields = {
+        -- ROLL FF
+        { x = 48, y = 26, min = 0, max = 2000, vals = { 33, 34 }, to = SMLSIZE },
+        -- PITCH FF
+        { x = 48, y = 36, min = 0, max = 2000, vals = { 35, 36 }, to = SMLSIZE },
+        -- YAW FF
+        { x = 48, y = 46, min = 0, max = 2000, vals = { 37, 38 }, to = SMLSIZE },
+        -- ROLL D MIN
+        { x = 80, y = 26, min = 0, max = 100,  vals = { 40 },     to = SMLSIZE },
+        -- PITCH D MIN
+        { x = 80, y = 36, min = 0, max = 100,  vals = { 41 },     to = SMLSIZE },
+        -- YAW D MIN
+        { x = 80, y = 46, min = 0, max = 100,  vals = { 42 },     to = SMLSIZE },
+        -- FF TRANSITION
+        { x = 80, y = 68, min = 0, max = 100,  vals = { 9 },      to = SMLSIZE, scale = 100 },
+        -- D MIN GAIN
+        { x = 80, y = 84, min = 0, max = 100,  vals = { 43 },     to = SMLSIZE },
+        -- D MIN ADVANCE
+        { x = 80, y = 92, min = 0, max = 200,  vals = { 44 },     to = SMLSIZE },
+    },
 }

--- a/src/SCRIPTS/BF/X9/pids2.lua
+++ b/src/SCRIPTS/BF/X9/pids2.lua
@@ -1,27 +1,44 @@
 
 return {
-   read           = 94, -- MSP_PID_ADVANCED
-   write          = 95, -- MSP_SET_PID_ADVANCED
-   title          = "PIDs (2/2)",
-   reboot         = false,
-   eepromWrite    = true,
-   minBytes       = 38,
-   text = {
-      { t = "Feed",       x =  63,  y = 11, to=SMLSIZE },
-      { t = "forward",    x =  55,  y = 18, to=SMLSIZE },
-      { t = "Transition", x =  101, y = 35, to=SMLSIZE },
-      { t = "ROLL",       x =  25,  y = 26, to=SMLSIZE },
-      { t = "PITCH",      x =  25,  y = 36, to=SMLSIZE },
-      { t = "YAW",        x =  25,  y = 46, to=SMLSIZE },
-   },
-   fields = {
-      -- ROLL FF
-      { x =  66,  y = 26, min = 0, max = 200, vals = { 33, 34 }, to=SMLSIZE },
-      -- PITCH FF
-      { x =  66,  y = 36, min = 0, max = 200, vals = { 35, 36 }, to=SMLSIZE },
-      -- YAW FF
-      { x =  66,  y = 46, min = 0, max = 200, vals = { 37, 38 }, to=SMLSIZE },
-      -- TRANSITION
-      { x =  160, y = 35, min = 0, max = 100, vals = { 9 },      to=SMLSIZE, scale = 100 },
-   },
+    read           = 94, -- MSP_PID_ADVANCED
+    write          = 95, -- MSP_SET_PID_ADVANCED
+    title          = "PIDs (2/2)",
+    reboot         = false,
+    eepromWrite    = true,
+    minBytes       = 44,
+    text = {
+        { t = "Feed",        x = 46,  y = 11, to = SMLSIZE },
+        { t = "forward",     x = 38,  y = 18, to = SMLSIZE },
+        { t = "D",           x = 86,  y = 11, to = SMLSIZE },
+        { t = "Min",         x = 81,  y = 18, to = SMLSIZE },
+        { t = "ROLL",        x = 8,   y = 26, to = SMLSIZE },
+        { t = "PITCH",       x = 8,   y = 36, to = SMLSIZE },
+        { t = "YAW",         x = 8,   y = 46, to = SMLSIZE },
+        
+        { t = "Feedforward", x = 110, y = 14, to = SMLSIZE },
+        { t = "Transition",  x = 120, y = 22, to = SMLSIZE },
+        { t = "D Min",       x = 110, y = 30, to = SMLSIZE },
+        { t = "Gain",        x = 120, y = 38, to = SMLSIZE },
+        { t = "Advance",     x = 120, y = 46, to = SMLSIZE },
+    },
+    fields = {
+        -- ROLL FF
+        { x = 49,  y = 26, min = 0, max = 2000, vals = { 33, 34 }, to = SMLSIZE },
+        -- PITCH FF
+        { x = 49,  y = 36, min = 0, max = 2000, vals = { 35, 36 }, to = SMLSIZE },
+        -- YAW FF
+        { x = 49,  y = 46, min = 0, max = 2000, vals = { 37, 38 }, to = SMLSIZE },
+        -- ROLL D MIN
+        { x = 81,  y = 26, min = 0, max = 100,  vals = { 40 },     to = SMLSIZE },
+        -- PITCH D MIN
+        { x = 81,  y = 36, min = 0, max = 100,  vals = { 41 },     to = SMLSIZE },
+        -- YAW D MIN
+        { x = 81,  y = 46, min = 0, max = 100,  vals = { 42 },     to = SMLSIZE },
+        -- FF TRANSITION
+        { x = 180, y = 22, min = 0, max = 100,  vals = { 9 },      to = SMLSIZE, scale = 100 },
+        -- D MIN GAIN
+        { x = 180, y = 38, min = 0, max = 100,  vals = { 43 },     to = SMLSIZE },
+        -- D MIN ADVANCE
+        { x = 180, y = 46, min = 0, max = 200,  vals = { 44 },     to = SMLSIZE },
+    },
 }


### PR DESCRIPTION
Adds D Min to pids2  page.

Tested with QX7. Tested in simulator on X9D+ and X12S.
Everything fits nicely on X9 and HORUS. For X7 the page scrolls.

Here's some screenshots. 

![screenshot_x7_19-04-04_14-43-35](https://user-images.githubusercontent.com/41271048/55557021-3a7ab600-56e9-11e9-90e8-c27a0f925f4c.png)

![screenshot_x7_19-04-04_14-43-43](https://user-images.githubusercontent.com/41271048/55557037-423a5a80-56e9-11e9-9298-d8130b7a6783.png)

![screenshot_x9d+_19-04-04_14-44-14](https://user-images.githubusercontent.com/41271048/55557046-46ff0e80-56e9-11e9-8398-886909ae96c3.png)

![screenshot_x12s_19-04-04_14-45-02](https://user-images.githubusercontent.com/41271048/55557056-4cf4ef80-56e9-11e9-8961-637f420e01e7.png)
