### PR TITLE
Scroll improvement

### DIFF
--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -180,7 +180,7 @@ local function drawScreen()
     local currentLineY = Page.fields[currentLine].y
     local screen_title = Page.title
     drawScreenTitle("Betaflight / "..screen_title)
-    if currentLine == 1 then
+    if currentLineY <= Page.fields[1].y then
         scrollPixelsY = 0
     elseif currentLineY - scrollPixelsY <= yMinLim then
         scrollPixelsY = currentLineY - yMinLim


### PR DESCRIPTION
This scrolls all the way to the top if the y-coordinate of the current field is equal or less than the y-coordinate of the first field. This is useful when theres a table at the top of the page. When scrolling up to the first row, the column headers will now be shown.