### PR TITLE
Prevent scrollover

### DIFF
--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -331,9 +331,9 @@ function run_ui(event)
             incPage(-1)
         elseif event == userEvent.release.menu or event == userEvent.press.pageDown then
             incPage(1)
-        elseif event == userEvent.release.plus or event == userEvent.dial.left then
+        elseif event == userEvent.release.plus or event == userEvent.repeatPress.plus or event == userEvent.dial.left then
             incLine(-1)
-        elseif event == userEvent.release.minus or event == userEvent.dial.right then
+        elseif event == userEvent.release.minus or event == userEvent.repeatPress.minus or event == userEvent.dial.right then
             incLine(1)
         elseif event == userEvent.release.enter then
             local field = Page.fields[currentLine]

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -150,11 +150,11 @@ local function incPage(inc)
 end
 
 local function incLine(inc)
-   currentLine = incMax(currentLine, inc, #(Page.fields))
+   currentLine = clipValue(currentLine + inc, 1, #(Page.fields))
 end
 
 local function incMenu(inc)
-   menuActive = incMax(menuActive, inc, #(menuList))
+   menuActive = clipValue(menuActive + inc, 1, #(menuList))
 end
 
 local function requestPage()


### PR DESCRIPTION
Prevents going back to the top of the page when scrolling past the end and vice versa. Does the same for the menu.
Also enables repeat press for quickly getting to the top/bottom for X9. 

Personally I find it very annoying to end up at the start after doing a quick spin on the rotary encoder to get to the bottom of the page. With this change it will just stop when you reach the first/last field.
The "downside" to this is that it's not consistent with how it works in the opentx pages. 

This is just a suggestion. If people prefer the way it currently is, I'm fine with that. 🙂 