### PR TITLE
Memory savings

### DIFF
--- a/src/SCRIPTS/BF/HORUS/horuspre.lua
+++ b/src/SCRIPTS/BF/HORUS/horuspre.lua
@@ -12,10 +12,6 @@ PageFiles =
     "gpspids.lua",
 }
 
-backgroundFill = TEXT_BGCOLOR
-foregroundColor = LINE_COLOR
-globalTextOptions = TEXT_COLOR
-
 MenuBox = { x=120, y=100, w=200, x_offset=68, h_line=20, h_offset=6 }
 SaveBox = { x=120, y=100, w=180, x_offset=12, h=60, h_offset=12 }
 NoTelem = {   192,   LCD_H - 28, "No Telemetry", TEXT_COLOR + INVERS + BLINK }

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -29,12 +29,12 @@ local lastRunTS = 0
 local killEnterBreak = 0
 local scrollPixelsY = 0
 
-Page = nil
+local Page = nil
 
-backgroundFill = backgroundFill or ERASE
-foregroundColor = foregroundColor or SOLID
+local backgroundFill = TEXT_BGCOLOR or ERASE
+local foregroundColor = LINE_COLOR or SOLID
 
-globalTextOptions = globalTextOptions or 0
+local globalTextOptions = TEXT_COLOR or 0
 
 local function saveSettings(new)
     if Page.values then

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -120,16 +120,16 @@ local function processMspReply(cmd,rx_buf)
 
         for i=1,#(Page.fields) do
             if (#(Page.values) or 0) >= Page.minBytes then
-               local f = Page.fields[i]
-               if f.vals then
-                  f.value = 0;
-                  for idx=1, #(f.vals) do
-                     local raw_val = (Page.values[f.vals[idx]] or 0)
-                     raw_val = bit32.lshift(raw_val, (idx-1)*8)
-                     f.value = bit32.bor(f.value, raw_val)
-                  end
-                  f.value = f.value/(f.scale or 1)
-               end
+                local f = Page.fields[i]
+                if f.vals then
+                    f.value = 0;
+                    for idx=1, #(f.vals) do
+                        local raw_val = (Page.values[f.vals[idx]] or 0)
+                        raw_val = bit32.lshift(raw_val, (idx-1)*8)
+                        f.value = bit32.bor(f.value, raw_val)
+                    end
+                    f.value = f.value/(f.scale or 1)
+                end
             end
         end
         if Page.postLoad then
@@ -139,22 +139,22 @@ local function processMspReply(cmd,rx_buf)
 end
 
 local function incMax(val, inc, base)
-   return ((val + inc + base - 1) % base) + 1
+    return ((val + inc + base - 1) % base) + 1
 end
 
 local function incPage(inc)
-   currentPage = incMax(currentPage, inc, #(PageFiles))
-   Page = nil
-   currentLine = 1
-   collectgarbage()
+    currentPage = incMax(currentPage, inc, #(PageFiles))
+    Page = nil
+    currentLine = 1
+    collectgarbage()
 end
 
 local function incLine(inc)
-   currentLine = clipValue(currentLine + inc, 1, #(Page.fields))
+    currentLine = clipValue(currentLine + inc, 1, #(Page.fields))
 end
 
 local function incMenu(inc)
-   menuActive = clipValue(menuActive + inc, 1, #(menuList))
+    menuActive = clipValue(menuActive + inc, 1, #(menuList))
 end
 
 local function requestPage()
@@ -201,7 +201,7 @@ local function drawScreen()
         local heading_options = text_options
         local value_options = text_options
         if i == currentLine then
-                value_options = text_options + INVERS
+            value_options = text_options + INVERS
             if currentState == pageStatus.editing then
                 value_options = value_options + BLINK
             end


### PR DESCRIPTION
Makes Page, backgroundFill, foregroundColor and globalTextOptions local to ui.lua. Removes the global variables from horuspre.lua and does the assignment in ui.lua.

I have noticed that global variables use a bit more memory than local variables. All of these variables are only used in ``ui.lua`` and can be made local. I'm printing ``collectgarbage("count")`` at the end of ``run_ui()`` on my QX7 and the total lua memory usage is about 1KB lower. The opentx statistics screen shows that "Free mem" is roughly 2-3KB higher than before which I believe indicates that peak memory usage is also reduced.

Also did some indentation fixes.