### PR TITLE
Offset label changed to be more appropriate

### DIFF
--- a/src/SCRIPTS/BF/X7/pwm.lua
+++ b/src/SCRIPTS/BF/X7/pwm.lua
@@ -12,7 +12,7 @@ return {
         { t = "Prot", x = 58, y = 14, to = SMLSIZE },
         { t = "Unsync", x = 58, y = 24, to = SMLSIZE },
         { t = "PWM", x = 58, y = 34, to = SMLSIZE },
-        { t = "Offset", x = 48, y = 44, to = SMLSIZE }
+        { t = "Idle", x = 58, y = 44, to = SMLSIZE }
     },
     fields = {
         { x = 32, y = 14, vals = { 9 }, min = 0, max = 1, to = SMLSIZE, table = { [0] = "OFF", "ON" }, upd = function(self) self.updateRateTables(self) end },


### PR DESCRIPTION
The label "Offset" was for me not clear what this does.
For the Horus and X9 there is room for an "Idle offset" label which is perfectly clear.

I think, for the X7, "Idle" is the best option, also set x=58 so it lines up nicely.
Tested on my QX7S.