### PR TITLE
Add support for Jumper T12 running OpenTX

### DIFF
--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -30,6 +30,7 @@ local supportedRadios =
     ["x3"] = supportedPlatforms.x7,
     ["x7"] = supportedPlatforms.x7,
     ["x7s"] = supportedPlatforms.x7,
+    ["t12"] = supportedPlatforms.x7,
     ["xlite"] = supportedPlatforms.x7,
     ["xlites"] = supportedPlatforms.x7,
     ["x9lite"] = supportedPlatforms.x7,


### PR DESCRIPTION
Tested ok on T12 + R9M running OpenTX 2.3 nightly for T12

![image](https://user-images.githubusercontent.com/5167938/60070859-89e4e700-9718-11e9-9262-eb30795343db.png)
