### PR TITLE
1.4.0 fixes

### DIFF
--- a/src/SCRIPTS/BF/MSP/common.lua
+++ b/src/SCRIPTS/BF/MSP/common.lua
@@ -129,6 +129,7 @@ function mspPollReply()
     while true do
         ret = protocol.mspPoll()
         if type(ret) == "table" then
+            mspLastReq = 0
             return mspRxReq, ret
         else
             break

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -337,10 +337,10 @@ function run_ui(event)
         end
     -- normal page viewing
     elseif currentState <= pageStatus.display then
-        if event == EVT_VIRTUAL_PREV_PAGE then
+        if not isTelemetryScript and event == EVT_VIRTUAL_PREV_PAGE then
             incPage(-1)
             killEvents(event) -- X10/T16 issue: pageUp is a long press
-        elseif event == EVT_VIRTUAL_NEXT_PAGE or event == EVT_VIRTUAL_MENU then
+        elseif (not isTelemetryScript and event == EVT_VIRTUAL_NEXT_PAGE) or (isTelemetryScript and event == EVT_VIRTUAL_MENU) then
             incPage(1)
         elseif event == EVT_VIRTUAL_PREV or event == EVT_VIRTUAL_PREV_REPT then
             incLine(-1)


### PR DESCRIPTION
This is an attempt at fixing 2 issues seen with 1.4.0:
- "BF script page changed when switch between telemetry page and script":
  - `NEXT_PAGE` / `PREV_PAGE` events are now only evaluated when the script is not executed as a telemetry script.
- "values changed back after editing":
  - this is probably caused by the fixed page reading timeout (800ms) generating multiple requests.
  - when the first reply has arrived, the user starts editing the page.
  - when the next reply arrives, the changes are wiped.
  - the fix invalidates subsequent replies.

Please use this zip file to test: 
[bf_lua-1.4.0-fixes.zip](https://github.com/betaflight/betaflight-tx-lua-scripts/files/3723615/bf_lua-1.4.0-fixes.zip)

