### PR TITLE
Add missing rx.lua script for X7

### DIFF
--- a/src/SCRIPTS/BF/X7/rx.lua
+++ b/src/SCRIPTS/BF/X7/rx.lua
@@ -1,0 +1,19 @@
+return {
+   read           = 44, -- MSP_RX_CONFIG
+   write          = 45, -- MSP_SET_RX_CONFIG
+   title          = "RX",
+   reboot         = false,
+   eepromWrite    = true,
+   minBytes       = 23,
+   yMinLimit      = 12,
+   yMaxLimit      = 52,
+   text = {},
+   fields = {
+      { t = "Stick Min",  x =  10, y = 20, sp = 45, min = 1000, max = 2000, vals = { 6, 7 }, to = SMLSIZE },
+      { t = "Stick Mid",  x =  10, y = 30, sp = 45, min = 1000, max = 2000, vals = { 4, 5 }, to = SMLSIZE },
+      { t = "Stick Max",  x =  10, y = 40, sp = 45, min = 1000, max = 2000, vals = { 2, 3 }, to = SMLSIZE },
+      { t = "Cam Angle",  x =  10, y = 50, sp = 50, min = 0, max = 90, vals = { 23 }, to = SMLSIZE },
+      { t = "Interp",     x =  10, y = 60, sp = 50, min = 0, max = 3, vals = { 13 }, to = SMLSIZE, table={ [0]="Off", "Preset", "Auto", "Manual"} },
+      { t = "Interp Int", x =  10, y = 70, sp = 50, min = 1, max = 50, vals = { 14 }, to = SMLSIZE },
+   },
+}

--- a/src/SCRIPTS/BF/X7/x7pre.lua
+++ b/src/SCRIPTS/BF/X7/x7pre.lua
@@ -7,6 +7,7 @@ PageFiles =
     { title = "Rates", script = "rates.lua"},
     { title = "Advanced PIDs", script = "pid_advanced.lua"},
     { title = "Filters", script = "filters.lua"},
+    { title = "Rx", script = "rx.lua"},
     { title = "GPS Rescue", script = "rescue.lua", requiredVersion = 1.041},
     { title = "GPS PIDs", script = "gpspids.lua", requiredVersion = 1.041},
 }


### PR DESCRIPTION
Adds the missing rx.lua script to the QX7 code. I've tested on the sim and looks ok - but needs further testing on real devices.