### PR TITLE
Remove killEvents() to fix EVT_VIRTUAL_DEC_REPT

### DIFF
--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -368,7 +368,6 @@ function run_ui(event)
             incValue(1)
         elseif event == EVT_VIRTUAL_DEC or event == EVT_VIRTUAL_DEC_REPT then
             incValue(-1)
-            killEvents(event)
         end
     end
     local nextPage = currentPage


### PR DESCRIPTION
long press '-' key did not respond like long press '+' key when editing values. Code line was leftover from pre-virtual events stage...