### PR TITLE
Main menu scroll fix

### DIFF
--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -14,7 +14,7 @@ local supportedRadios =
         SaveBox         = { x=15, y=12, w=100, x_offset=4,  h=30, h_offset=5 },
         NoTelem         = { 30, 55, "No Telemetry", BLINK },
         textSize        = SMLSIZE,
-        yMinLimit       = 11,
+        yMinLimit       = 12,
         yMaxLimit       = 52,
     },
     ["212x64"]  = 

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -389,7 +389,9 @@ function run_ui(event)
     if TEXT_BGCOLOR then
         lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, TEXT_BGCOLOR)
     end
-    drawScreen()
+    if currentState ~= pageStatus.mainMenu then
+        drawScreen()
+    end
     if protocol.rssi() == 0 then
         lcd.drawText(radio.NoTelem[1],radio.NoTelem[2],radio.NoTelem[3],radio.NoTelem[4])
     end

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -424,8 +424,8 @@ function run_ui(event)
         end
         for i=1, #PageFiles do
             if (not PageFiles[i].requiredVersion) or (apiVersion == 0) or (apiVersion > 0 and PageFiles[i].requiredVersion < apiVersion) then
-                local currentLineY = (menuLine-1)*lineSpacing + yMinLim + 1
-                if currentLineY <= yMaxLim then
+                local currentLineY = (menuLine-1)*lineSpacing + yMinLim
+                if currentLineY <= yMinLim then
                     scrollPixelsY = 0
                 elseif currentLineY - scrollPixelsY <= yMinLim then
                     scrollPixelsY = currentLineY - yMinLim


### PR DESCRIPTION
Changes ``yMinLimit`` for 128x64 to be the same as for 212x64. Makes sense as they're the same height. 
Prevents``drawScreen()`` from running when the main menu is visible. This function can change ``scrollPixelsY`` causing the scrolling to not work as it should on the main menu. Also no need to run it when on the main menu.
Removed the ``+1`` from the ``currentLineY`` calculation. Adding 1 causes the text at the top of the page to be placed outside ``yMinLim`` and disappear. 
Also corrected a limit error where it should be min instead of max.
Now it works just like on the other pages. Tested and works. 