### PR TITLE
Reduce peak memory use

### DIFF
--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -74,6 +74,7 @@ local function invalidatePages()
     Page = nil
     currentState = pageStatus.display
     saveTS = 0
+    collectgarbage()
 end
 
 local function rebootFc()
@@ -432,7 +433,7 @@ function run_ui(event)
                 end
                 local attr = (menuLine == i and INVERS or 0)
                 if event == EVT_VIRTUAL_ENTER and attr == INVERS then
-                    Page = assert(loadScript(SCRIPT_HOME.."/Pages/"..PageFiles[i].script))()
+                    invalidatePages()
                     currentPage = i
                     currentState = pageStatus.display
                 end


### PR DESCRIPTION
During some operations there are some pretty large memory usage peaks. 
When reloading a page from the menu there is a peak, but not when switching to another page. When reloading a page, ``invalidatePages()`` is called but there is no ``collectgarbage()`` as in ``incPage()``. Then we might have two copies of the same page loaded for a brief moment.
Added ``collectgarbage()`` to ``invalidatePages()`` to deal with this. 

The second case is when selecting a page from the main menu. Here we also end up with two pages in memory. The script will load a page in the background and the main menu code will load a page when pressing enter. 
Removed the page loading in the main menu code and replaced it with ``invalidatePages()`` which now also collects garbage. Then the page can be loaded by the code that is already in place to do it. 

I have done multiple tests with and without these changes. Now I'm seeing dips in memory use when selecting a page from the main menu. When reloading a page it's the same as when switching between pages. Opentx shows that free memory has increased by over 10kb