### PR TITLE
Prevent Page access if nil

### DIFF
--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -105,6 +105,9 @@ local function processMspReply(cmd,rx_buf)
     if cmd == nil or rx_buf == nil then
         return
     end
+    if Page == nil then
+        return
+    end
     if cmd == Page.write then
         if Page.eepromWrite then
             eepromWrite()
@@ -349,10 +352,12 @@ function run_ui(event)
         elseif event == EVT_VIRTUAL_NEXT or event == EVT_VIRTUAL_NEXT_REPT then
             incLine(1)
         elseif event == EVT_VIRTUAL_ENTER then
-            local field = Page.fields[currentLine]
-            local idx = field.i or currentLine
-            if Page.values and Page.values[idx] and (field.ro ~= true) then
-                currentState = pageStatus.editing
+            if Page then
+                local field = Page.fields[currentLine]
+                local idx = field.i or currentLine
+                if Page.values and Page.values[idx] and (field.ro ~= true) then
+                    currentState = pageStatus.editing
+                end
             end
         elseif event == EVT_VIRTUAL_EXIT then
             if isTelemetryScript then 


### PR DESCRIPTION
If there are no pages and the message ``No Pages! API: `` is shown, the script will crash when pressing enter. It tries to access ``Page`` which is nil.

After #278 we are now unloading ``Page`` when selecting a page from the main menu to avoid the situation where there's two pages in memory. Then there's a small chance that ``Page == nil`` when ``processMspReply()`` tries to access it. I haven't been able to make it happen yet, but it's possible. 

These are the only two cases I can find where this can happen.