### PR TITLE
UI states + apiVersion detection for TOOLS script

### DIFF
--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -1,7 +1,8 @@
 local uiStatus =
 {
-    mainMenu = 1,
+    init     = 1,
     pages    = 2,
+    mainMenu = 3,
 }
 
 local pageStatus =
@@ -20,7 +21,7 @@ local uiMsp =
 
 local menuLine = 1
 local pageCount = 1
-local uiState = uiStatus.mainMenu
+local uiState = uiStatus.init
 local pageState = pageStatus.display
 local requestTimeout = 80 -- 800ms request timeout
 local currentPage = 1
@@ -37,6 +38,7 @@ local pageScrollY = 0
 local mainMenuScrollY = 0
 
 local Page = nil
+local background = nil
 
 local backgroundFill = TEXT_BGCOLOR or ERASE
 local foregroundColor = LINE_COLOR or SOLID
@@ -298,14 +300,32 @@ function run_ui(event)
         if isTelemetryScript then
             uiState = uiStatus.pages
         else
-            uiState = uiStatus.mainMenu
+            uiState = uiStatus.init
         end
     end
     lastRunTS = now
     if isTelemetryScript then
         uiState = uiStatus.pages
     end
-    if uiState == uiStatus.mainMenu then
+    if uiState == uiStatus.init then
+        local yMinLim = radio.yMinLimit
+        lcd.clear()
+        drawScreenTitle("Betaflight Config", 0, 0)
+        lcd.drawText(6, yMinLim, "Initialising")
+        if apiVersion == 0 then
+            if not background then
+                background = assert(loadScript("/SCRIPTS/BF/background.lua"))()
+                background.init()
+            else
+                background.run_bg()
+            end
+            return 0
+        else
+            background = nil
+            invalidatePages()
+            uiState = uiStatus.mainMenu
+        end
+    elseif uiState == uiStatus.mainMenu then
         getPageCount()
         if event == EVT_VIRTUAL_EXIT then
             return 2

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -297,16 +297,9 @@ function run_ui(event)
     -- if lastRunTS old than 500ms
     if lastRunTS + 50 < now then
         invalidatePages()
-        if isTelemetryScript then
-            uiState = uiStatus.pages
-        else
-            uiState = uiStatus.init
-        end
+        uiState = uiStatus.init
     end
     lastRunTS = now
-    if isTelemetryScript then
-        uiState = uiStatus.pages
-    end
     if uiState == uiStatus.init then
         local yMinLim = radio.yMinLimit
         lcd.clear()
@@ -323,7 +316,11 @@ function run_ui(event)
         else
             background = nil
             invalidatePages()
-            uiState = uiStatus.mainMenu
+            if isTelemetryScript then
+                uiState = uiStatus.pages
+            else
+                uiState = uiStatus.mainMenu
+            end
         end
     elseif uiState == uiStatus.mainMenu then
         getPageCount()

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -48,7 +48,7 @@ local globalTextOptions = TEXT_COLOR or 0
 local function getPageCount()
     pageCount = 0
     for i=1,#(PageFiles) do
-        if (not PageFiles[i].requiredVersion) or (apiVersion == 0) or (apiVersion > 0 and PageFiles[i].requiredVersion < apiVersion) then
+        if (not PageFiles[i].requiredVersion) or (apiVersion == 0) or (apiVersion > 0 and PageFiles[i].requiredVersion <= apiVersion) then
             pageCount = pageCount + 1
         end
     end
@@ -343,7 +343,7 @@ function run_ui(event)
             lineSpacing = 25
         end
         for i=1, #PageFiles do
-            if (not PageFiles[i].requiredVersion) or (apiVersion == 0) or (apiVersion > 0 and PageFiles[i].requiredVersion < apiVersion) then
+            if (not PageFiles[i].requiredVersion) or (apiVersion == 0) or (apiVersion > 0 and PageFiles[i].requiredVersion <= apiVersion) then
                 local currentLineY = (menuLine-1)*lineSpacing + yMinLim
                 if currentLineY <= yMinLim then
                     mainMenuScrollY = 0

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -25,7 +25,7 @@ local uiState = uiStatus.init
 local pageState = pageStatus.display
 local requestTimeout = 80 -- 800ms request timeout
 local currentPage = 1
-local currentLine = 1
+local currentField = 1
 local saveTS = 0
 local saveTimeout = 0
 local saveRetries = 0
@@ -166,13 +166,13 @@ end
 local function incPage(inc)
     currentPage = incMax(currentPage, inc, #(PageFiles))
     Page = nil
-    currentLine = 1
+    currentField = 1
     menuLine = currentPage
     collectgarbage()
 end
 
 local function incLine(inc)
-    currentLine = clipValue(currentLine + inc, 1, #(Page.fields))
+    currentField = clipValue(currentField + inc, 1, #(Page.fields))
 end
 
 local function incMainMenu(inc)
@@ -203,15 +203,15 @@ end
 local function drawScreen()
     local yMinLim = radio.yMinLimit or 0
     local yMaxLim = radio.yMaxLimit or LCD_H
-    local currentLineY = Page.fieldLayout[currentLine].y
+    local currentFieldY = Page.fieldLayout[currentField].y
     local screen_title = Page.title
     drawScreenTitle("Betaflight / "..screen_title)
-    if currentLineY <= Page.fieldLayout[1].y then
+    if currentFieldY <= Page.fieldLayout[1].y then
         pageScrollY = 0
-    elseif currentLineY - pageScrollY <= yMinLim then
-        pageScrollY = currentLineY - yMinLim
-    elseif currentLineY - pageScrollY >= yMaxLim then
-        pageScrollY = currentLineY - yMaxLim
+    elseif currentFieldY - pageScrollY <= yMinLim then
+        pageScrollY = currentFieldY - yMinLim
+    elseif currentFieldY - pageScrollY >= yMaxLim then
+        pageScrollY = currentFieldY - yMaxLim
     end
     for i=1,#(Page.labels) do
         local f = Page.labels[i]
@@ -226,7 +226,7 @@ local function drawScreen()
         local pos = Page.fieldLayout[i]
         local text_options = radio.textSize + globalTextOptions
         local value_options = text_options
-        if i == currentLine then
+        if i == currentField then
             value_options = text_options + INVERS
             if pageState == pageStatus.editing then
                 value_options = value_options + BLINK
@@ -257,8 +257,8 @@ function clipValue(val,min,max)
 end
 
 local function incValue(inc)
-    local f = Page.fields[currentLine]
-    local idx = f.i or currentLine
+    local f = Page.fields[currentField]
+    local idx = f.i or currentField
     local scale = (f.scale or 1)
     local mult = (f.mult or 1)
     f.value = clipValue(f.value + ((inc*mult)/scale), (f.min/scale) or 0, (f.max/scale) or 255)
@@ -344,13 +344,13 @@ function run_ui(event)
         end
         for i=1, #PageFiles do
             if (not PageFiles[i].requiredVersion) or (apiVersion == 0) or (apiVersion > 0 and PageFiles[i].requiredVersion <= apiVersion) then
-                local currentLineY = (menuLine-1)*lineSpacing + yMinLim
-                if currentLineY <= yMinLim then
+                local currentFieldY = (menuLine-1)*lineSpacing + yMinLim
+                if currentFieldY <= yMinLim then
                     mainMenuScrollY = 0
-                elseif currentLineY - mainMenuScrollY <= yMinLim then
-                    mainMenuScrollY = currentLineY - yMinLim
-                elseif currentLineY - mainMenuScrollY >= yMaxLim then
-                    mainMenuScrollY = currentLineY - yMaxLim
+                elseif currentFieldY - mainMenuScrollY <= yMinLim then
+                    mainMenuScrollY = currentFieldY - yMinLim
+                elseif currentFieldY - mainMenuScrollY >= yMaxLim then
+                    mainMenuScrollY = currentFieldY - yMaxLim
                 end
                 local attr = (menuLine == i and INVERS or 0)
                 if event == EVT_VIRTUAL_ENTER and attr == INVERS then
@@ -413,8 +413,8 @@ function run_ui(event)
                 incLine(1)
             elseif event == EVT_VIRTUAL_ENTER then
                 if Page then
-                    local field = Page.fields[currentLine]
-                    local idx = field.i or currentLine
+                    local field = Page.fields[currentField]
+                    local idx = field.i or currentField
                     if Page.values and Page.values[idx] and (field.ro ~= true) then
                         pageState = pageStatus.editing
                     end
@@ -469,7 +469,7 @@ function run_ui(event)
         end
         if stopDisplay and (not isTelemetryScript) then
             invalidatePages()
-            currentLine = 1
+            currentField = 1
             uiState = uiStatus.mainMenu
             stopDisplay = false
         end


### PR DESCRIPTION
Adds UI states. This makes it easier to organise the code in ``run_ui()`` and gives us more control over what is executed and when it's executed.

There's three states:

- ``init`` for init stuff like ``apiVersion`` detection

- ``mainMenu`` for the main menu code

- ``pages`` for page code

``apiVersion`` detection for TOOLS script is done by using ``background.lua`` for now.
It works by entering the ``init`` state when starting the script. It stays in this state until power is connected to the quad and it receives the ``apiVersion``. If the quad is already powered this check only takes a second before it then moves onto the ``mainMenu`` state. No pages are loaded until one is selected from the menu. Pages are unloaded when leaving the ``pages`` state. 

The TELEMETRY version works as before with ``background.lua`` doing ``apiVersion`` detection in the background. ~~It's always forced to ``pages`` state.~~
EDIT: Added commit to allow detecting ``apiVersion`` in init state for TELEMETRY script too. It's useful in those cases where the ui is brought on screen before ``background.lua`` is done with init. Doesn't use more memory since the memory use in init state is well below the peak memory use.

``currentState``(renamed to ``pageState``) is now only used for pages.

``currentLine`` is renamed to ``currentField`` as that's a better description of what it actually is.

Fixed ``api/requiredVersion`` check for the main menu.


I have tested this for a while now and haven't found anything that doesn't work like it should. Memory use is pretty much the same as it currently is.
