### PR TITLE
Unload background when not used + other minor changes

### DIFF
--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -2,7 +2,7 @@ local INTERVAL          = 50         -- in 1/100th seconds
 
 local MSP_TX_INFO       = 186
 
-local lastRunTS
+local lastRunTS = 0
 local sensorId = -1
 local dataInitialised = false
 local data_init = nil
@@ -21,10 +21,6 @@ local function modelActive(sensorValue)
     return type(sensorValue) == "number" and sensorValue > 0
 end
 
-local function init()
-    lastRunTS = 0
-end
-
 local function run_bg()
     -- run in intervals
     if lastRunTS == 0 or lastRunTS + INTERVAL < getTime() then
@@ -37,7 +33,7 @@ local function run_bg()
                     data_init = assert(loadScript(SCRIPT_HOME .. "/data_init.lua"))()
                 end
 
-                dataInitialised = data_init.init();
+                dataInitialised = data_init();
 
                 if dataInitialised then
                     data_init = nil
@@ -52,7 +48,7 @@ local function run_bg()
                     rssi = 255
                 end
 
-                values = {}
+                local values = {}
                 values[1] = rssi
 
                 protocol.mspWrite(MSP_TX_INFO, values)
@@ -68,4 +64,4 @@ local function run_bg()
     mspProcessTxQ()
 end
 
-return { init=init, run_bg=run_bg }
+return run_bg

--- a/src/SCRIPTS/BF/data_init.lua
+++ b/src/SCRIPTS/BF/data_init.lua
@@ -23,12 +23,10 @@ local function init()
     elseif apiVersionReceived and not timeIsSet then
         -- only send datetime one time after telemetry connection became available
         -- or when connection is restored after e.g. lipo refresh
-
+        local values = {}
         if apiVersion >= 1.041 then
             -- format: seconds after the epoch (32) / milliseconds (16)
             local now = getRtcTime()
-
-            values = {}
 
             for i = 1, 4 do
                 values[i] = bit32.band(now, 0xFF)
@@ -42,7 +40,6 @@ local function init()
             local now = getDateTime()
             local year = now.year;
 
-            values = {}
             values[1] = bit32.band(year, 0xFF)
             year = bit32.rshift(year, 8)
             values[2] = bit32.band(year, 0xFF)
@@ -61,4 +58,4 @@ local function init()
     return apiVersionReceived and timeIsSet
 end
 
-return { init=init }
+return init

--- a/src/SCRIPTS/TELEMETRY/bf.lua
+++ b/src/SCRIPTS/TELEMETRY/bf.lua
@@ -17,15 +17,23 @@ local MENU_TIMESLICE = 100
 
 local lastMenuEvent = 0
 
-function run(event)
-  lastMenuEvent = getTime()
-  run_ui(event)
+local function run(event)
+    if background then
+        background = nil
+        collectgarbage()
+    end
+    lastMenuEvent = getTime()
+    run_ui(event)
 end
 
-function run_bg()
-  if lastMenuEvent + MENU_TIMESLICE < getTime() then
-    background.run_bg()
-  end
+local function run_bg()
+    if lastMenuEvent + MENU_TIMESLICE < getTime() then
+        if not background then
+            background = assert(loadScript(SCRIPT_HOME.."/background.lua"))()
+            collectgarbage()
+        end
+        background()
+    end
 end
 
-return { init=background.init, run=run, background=run_bg }
+return { run=run, background=run_bg }


### PR DESCRIPTION
Unloads background when ui is visible. It's prevented from running anyway.
Removed optional init function.
``+`` some minor simplifications.
Saves around 2KB for telemetry script.
This means that ``background`` will redetect ``apiVersion`` and set the time when it's loaded again. But that's ok IMO. 

Also separated event handling from lcd draw code for the main menu.

``+`` some other minor changes. 

Have tested this and everything works as it should.