### PR TITLE
Fix no telemetry blink for high res LCDs

### DIFF
--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -34,7 +34,7 @@ local supportedRadios =
         resolution      = lcdResolution.high,
         MenuBox         = { x=120, y=100, w=200, x_offset=68, h_line=20, h_offset=6 },
         SaveBox         = { x=120, y=100, w=180, x_offset=12, h=60, h_offset=12 },
-        NoTelem         = {   192,   LCD_H - 28, "No Telemetry", BLINK },
+        NoTelem         = { 192, LCD_H - 28, "No Telemetry", TEXT_COLOR + INVERS + BLINK },
         textSize        = 0,
         yMinLimit       = 35,
         yMaxLimit       = 235,
@@ -45,10 +45,10 @@ local supportedRadios =
         resolution      = lcdResolution.high,
         MenuBox         = { x= (LCD_W -200)/2, y=LCD_H/2, w=200, x_offset=68, h_line=20, h_offset=6 },
         SaveBox         = { x= (LCD_W -200)/2, y=LCD_H/2, w=180, x_offset=12, h=60, h_offset=12 },
-        NoTelem         = { LCD_W/2 - 50, LCD_H - 28, "No Telemetry", BLINK },
+        NoTelem         = { LCD_W/2 - 50, LCD_H - 28, "No Telemetry", TEXT_COLOR + INVERS + BLINK },
         textSize        = 0,
         yMinLimit       = 35,
-        yMaxLimit       = 235,
+        yMaxLimit       = 435,
     },
 }
 


### PR DESCRIPTION
Seems like BLINK on it's own doesn't work for the high resolution screens.
Changed it back to what it used to be. Works in the simulator.

Extended yMaxLimit for 320x480.