### PR TITLE
Larger font size and placement for the 480x272 screen

### DIFF
--- a/src/SCRIPTS/BF/TEMPLATES/480x272/default_template.lua
+++ b/src/SCRIPTS/BF/TEMPLATES/480x272/default_template.lua
@@ -1,7 +1,7 @@
 return {
-    margin       = 5,
+    margin       = 10,
     indent       = 15,
-    lineSpacing  = 20,
-    listSpacing  = { line = 20, field = 170 },
-    tableSpacing = { row = 25, col = 60, header = 20 },
+    lineSpacing  = 25,
+    listSpacing  = { line = 25, field = 240 },
+    tableSpacing = { row = 35, col = 120, header = 20 },
 }

--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -35,7 +35,7 @@ local supportedRadios =
         MenuBox         = { x=120, y=100, w=200, x_offset=68, h_line=20, h_offset=6 },
         SaveBox         = { x=120, y=100, w=180, x_offset=12, h=60, h_offset=12 },
         NoTelem         = {   192,   LCD_H - 28, "No Telemetry", BLINK },
-        textSize        = 0,
+        textSize        = MIDSIZE,
         yMinLimit       = 35,
         yMaxLimit       = 235,
     },


### PR DESCRIPTION
Allows a larger font size and screen placement on the 480 x 272 screen sized radios.
All eleven screenshots are available for review as "Screenshots.zip" in issue #294 .

 
![PID-01_MIDSIZE](https://user-images.githubusercontent.com/26642502/70590808-d2e30780-1ba1-11ea-9585-67a31acec07a.jpg)
