### PR TITLE
Improve protocol detection

### DIFF
--- a/src/SCRIPTS/BF/protocols.lua
+++ b/src/SCRIPTS/BF/protocols.lua
@@ -27,9 +27,9 @@ local supportedProtocols =
 }
 
 local function getProtocol()
-    if supportedProtocols.smartPort.push() then
+    if supportedProtocols.smartPort.push() ~= nil then
         return supportedProtocols.smartPort
-    elseif supportedProtocols.crsf.push() then
+    elseif supportedProtocols.crsf.push() ~= nil then
         return supportedProtocols.crsf
     end
 end


### PR DESCRIPTION
From OpenTX 2.3.4 sport/crossfireTelemetryPush behaviour is changed.
These functions will now return nil if incorrect telemetry protocol is detected.
https://github.com/opentx/opentx/pull/7229

This should get rid of "script syntax error telemetry protocol not supported" if it's caused by the buffer not being available when the telemetryPush functions are called. This allows scripts that do protocol detection like BF lua to reliably start even if some other script has put something in the buffer.

OpenTX 2.3.4 is a requirement for this to work. It was just released https://github.com/opentx/opentx/releases/tag/release%2F2.3.4

