### PR TITLE
RSSI function script

### DIFF
--- a/src/SCRIPTS/FUNCTIONS/rssi.lua
+++ b/src/SCRIPTS/FUNCTIONS/rssi.lua
@@ -1,0 +1,8 @@
+SCRIPT_HOME = "/SCRIPTS/BF"
+apiVersion = 0
+protocol = assert(loadScript(SCRIPT_HOME.."/protocols.lua"))()
+assert(loadScript(protocol.transport))()
+assert(loadScript(SCRIPT_HOME.."/MSP/common.lua"))()
+local background = assert(loadScript(SCRIPT_HOME.."/background.lua"))()
+
+return { run=background }


### PR DESCRIPTION
background.lua as a function script.
Gives us the functionality of background.lua without having the telemetry script running. Useful for those who prefer using the tools script but also need rssi or setting of rtc at startup.
#300 makes this work.
