### PR TITLE
Remove TELEMETRY script

### DIFF
--- a/src/SCRIPTS/BF/protocols.lua
+++ b/src/SCRIPTS/BF/protocols.lua
@@ -4,7 +4,6 @@ local supportedProtocols =
     {
         transport       = SCRIPT_HOME.."/MSP/sp.lua",
         rssi            = function() return getValue("RSSI") end,
-        exitFunc        = function() return 0 end,
         stateSensor     = "Tmp1",
         push            = sportTelemetryPush,
         maxTxBufferSize = 6,
@@ -16,7 +15,6 @@ local supportedProtocols =
     {
         transport       = SCRIPT_HOME.."/MSP/crsf.lua",
         rssi            = function() return getValue("TQly") end,
-        exitFunc        = function() return "/CROSSFIRE/crossfire.lua" end,
         stateSensor     = "1RSS",
         push            = crossfireTelemetryPush,
         maxTxBufferSize = 8,

--- a/src/SCRIPTS/TELEMETRY/bf.lua
+++ b/src/SCRIPTS/TELEMETRY/bf.lua
@@ -1,39 +1,6 @@
-SCRIPT_HOME = "/SCRIPTS/BF"
-
-apiVersion = 0
-isTelemetryScript = true
-
-protocol = assert(loadScript(SCRIPT_HOME.."/protocols.lua"))()
-radio = assert(loadScript(SCRIPT_HOME.."/radios.lua"))()
-
-assert(loadScript(SCRIPT_HOME.."/pages.lua"))()
-assert(loadScript(protocol.transport))()
-assert(loadScript(SCRIPT_HOME.."/MSP/common.lua"))()
-
-local run_ui = assert(loadScript(SCRIPT_HOME.."/ui.lua"))()
-local background = assert(loadScript(SCRIPT_HOME.."/background.lua"))()
-
-local MENU_TIMESLICE = 100
-
-local lastMenuEvent = 0
-
 local function run(event)
-    if background then
-        background = nil
-        collectgarbage()
-    end
-    lastMenuEvent = getTime()
-    run_ui(event)
+    lcd.clear()
+    lcd.drawText(2, 2, "Use TOOLS menu instead of this")
 end
 
-local function run_bg()
-    if lastMenuEvent + MENU_TIMESLICE < getTime() then
-        if not background then
-            background = assert(loadScript(SCRIPT_HOME.."/background.lua"))()
-            collectgarbage()
-        end
-        background()
-    end
-end
-
-return { run=run, background=run_bg }
+return { run=run }

--- a/src/SCRIPTS/TOOLS/bf.lua
+++ b/src/SCRIPTS/TOOLS/bf.lua
@@ -2,12 +2,10 @@ local toolName = "TNS|Betaflight setup|TNE"
 SCRIPT_HOME = "/SCRIPTS/BF"
 
 apiVersion = 0
-isTelemetryScript = false
 
 protocol = assert(loadScript(SCRIPT_HOME.."/protocols.lua"))()
 radio = assert(loadScript(SCRIPT_HOME.."/radios.lua"))()
 
-assert(loadScript(SCRIPT_HOME.."/pages.lua"))()
 assert(loadScript(protocol.transport))()
 assert(loadScript(SCRIPT_HOME.."/MSP/common.lua"))()
 


### PR DESCRIPTION
As discussed in #302 
Removes the telemetry version of the script.
bf.lua still exists but only displays a message telling the user to use the TOOLS version instead. bf.lua should be removed from the TELEMETRY folder at a later time.

Now that we have the script available as a one-time script in the tools menu, there aren't many good reasons to keep the telemetry version IMO. There are many benefits to just having the tools version.
Uses less memory.
Frees up a lot of memory that can be used for actual telemetry scripts.
All scripts are stopped when starting one-time script. This means more available memory for BF lua.
Keys work as expected.
Avoids potential conflicts with other scripts using the opentx telemetryPush/Pop functions.
