### PR TITLE
Memory saving + ui.lua size reduction

### DIFF
--- a/src/SCRIPTS/BF/MSP/common.lua
+++ b/src/SCRIPTS/BF/MSP/common.lua
@@ -6,7 +6,6 @@ local MSP_STARTFLAG = bit32.lshift(1,4)
 local mspSeq = 0
 local mspRemoteSeq = 0
 local mspRxBuf = {}
-local mspRxIdx = 1
 local mspRxCRC = 0
 local mspRxReq = 0
 local mspStarted = false
@@ -14,7 +13,6 @@ local mspLastReq = 0
 local mspTxBuf = {}
 local mspTxIdx = 1
 local mspTxCRC = 0
-local mspTxPk = 0
 
 function mspProcessTxQ()
     if (#(mspTxBuf) == 0) then
@@ -31,10 +29,7 @@ function mspProcessTxQ()
         payload[1] = payload[1] + MSP_STARTFLAG
     end
     local i = 2
-    while (i <= protocol.maxTxBufferSize) do
-        if mspTxIdx > #(mspTxBuf) then
-            break
-        end
+    while (i <= protocol.maxTxBufferSize) and mspTxIdx <= #mspTxBuf do
         payload[i] = mspTxBuf[mspTxIdx]
         mspTxIdx = mspTxIdx + 1
         mspTxCRC = bit32.bxor(mspTxCRC,payload[i])  
@@ -48,17 +43,13 @@ function mspProcessTxQ()
             payload[i] = 0
             i = i + 1
         end
-        if protocol.mspSend(payload) then
-            mspTxPk = mspTxPk + 1
-        end
+        protocol.mspSend(payload)
         mspTxBuf = {}
         mspTxIdx = 1
-        mspTxCRC = 0     
+        mspTxCRC = 0
         return false
     end
-    if protocol.mspSend(payload) then
-        mspTxPk = mspTxPk + 1
-    end
+    protocol.mspSend(payload)
     return true
 end
 
@@ -90,7 +81,6 @@ function mspReceivedReply(payload)
     local seq   = bit32.band(head,0x0F)
     if start then
         -- start flag set
-        mspRxIdx = 1
         mspRxBuf = {}
         mspRxSize = payload[idx]
         mspRxCRC  = bit32.bxor(mspRxSize,mspLastReq)
@@ -103,28 +93,26 @@ function mspReceivedReply(payload)
         mspStarted = false
         return nil
     end
-    while (idx <= protocol.maxRxBufferSize) and (mspRxIdx <= mspRxSize) do
-        mspRxBuf[mspRxIdx] = payload[idx]
+    while (idx <= protocol.maxRxBufferSize) and (#mspRxBuf < mspRxSize) do
+        mspRxBuf[#mspRxBuf + 1] = payload[idx]
         mspRxCRC = bit32.bxor(mspRxCRC,payload[idx])
-        mspRxIdx = mspRxIdx + 1
         idx = idx + 1
     end
     if idx > protocol.maxRxBufferSize then
         mspRemoteSeq = seq
         return true
     end
+    mspStarted = false
     -- check CRC
     if mspRxCRC ~= payload[idx] then
-        mspStarted = false
         return nil
     end
-    mspStarted = false
     return mspRxBuf
 end
 
 function mspPollReply()
     while true do
-        ret = protocol.mspPoll()
+        local ret = protocol.mspPoll()
         if type(ret) == "table" then
             mspLastReq = 0
             return mspRxReq, ret

--- a/src/SCRIPTS/BF/MSP/crsf.lua
+++ b/src/SCRIPTS/BF/MSP/crsf.lua
@@ -13,7 +13,7 @@ protocol.mspSend = function(payload)
     for i=1, #(payload) do
         payloadOut[i+2] = payload[i]
     end
-    return crossfireTelemetryPush(crsfMspCmd, payloadOut)
+    return protocol.push(crsfMspCmd, payloadOut)
 end
 
 protocol.mspRead = function(cmd)

--- a/src/SCRIPTS/BF/MSP/sp.lua
+++ b/src/SCRIPTS/BF/MSP/sp.lua
@@ -7,12 +7,10 @@ local REPLY_FRAME_ID   = 0x32
 local lastSensorId, lastFrameId, lastDataId, lastValue
 
 protocol.mspSend = function(payload)
-    local dataId = 0
-    dataId = payload[1] + bit32.lshift(payload[2],8)
-    local value = 0
-    value = payload[3] + bit32.lshift(payload[4],8)
+    local dataId = payload[1] + bit32.lshift(payload[2],8)
+    local value = payload[3] + bit32.lshift(payload[4],8)
         + bit32.lshift(payload[5],16) + bit32.lshift(payload[6],24)
-    return sportTelemetryPush(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
+    return protocol.push(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
 end
 
 protocol.mspRead = function(cmd)
@@ -23,15 +21,14 @@ protocol.mspWrite = function(cmd, payload)
     return mspSendRequest(cmd, payload)
 end
 
---Discards duplicate data from lua input buffer
+-- Discards duplicate data from lua input buffer
 local function smartPortTelemetryPop()
-    local sensorId, frameId, dataId, value
     while true do
-        sensorId, frameId, dataId, value = sportTelemetryPop()
-        if sensorId == nil then
+        local sensorId, frameId, dataId, value = sportTelemetryPop()
+        if not sensorId then
             return nil
         elseif (lastSensorId == sensorId) and (lastFrameId == frameId) and (lastDataId == dataId) and (lastValue == value) then
-            --Keep checking
+            -- Keep checking
         else
             lastSensorId = sensorId
             lastFrameId = frameId

--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -25,7 +25,7 @@ local function run_bg()
         -- assuming when sensor value higher than 0 there is an telemetry connection
         if not dataInitialised then
             if not data_init then
-                data_init = assert(loadScript(SCRIPT_HOME .. "/data_init.lua"))()
+                data_init = assert(loadScript("data_init.lua"))()
             end
 
             dataInitialised = data_init()
@@ -37,7 +37,7 @@ local function run_bg()
             end
         elseif rssiEnabled and apiVersion >= 1.037 then
             if not rssiTask then
-                rssiTask = assert(loadScript(SCRIPT_HOME.."/rssi.lua"))()
+                rssiTask = assert(loadScript("rssi.lua"))()
             end
 
             rssiEnabled = rssiTask()

--- a/src/SCRIPTS/BF/protocols.lua
+++ b/src/SCRIPTS/BF/protocols.lua
@@ -2,7 +2,7 @@ local supportedProtocols =
 {
     smartPort =
     {
-        transport       = SCRIPT_HOME.."/MSP/sp.lua",
+        transport       = "MSP/sp.lua",
         rssi            = function() return getValue("RSSI") end,
         stateSensor     = "Tmp1",
         push            = sportTelemetryPush,
@@ -13,7 +13,7 @@ local supportedProtocols =
     },
     crsf =
     {
-        transport       = SCRIPT_HOME.."/MSP/crsf.lua",
+        transport       = "MSP/crsf.lua",
         rssi            = function() return getValue("TQly") end,
         stateSensor     = "1RSS",
         push            = crossfireTelemetryPush,

--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -1,15 +1,8 @@
-lcdResolution =
-{
-    low = 0,
-    high = 1
-}
-
 local supportedRadios =
 {
     ["128x64"]  = 
     {
-        templateHome    = SCRIPT_HOME.."/TEMPLATES/128x64/",
-        resolution      = lcdResolution.low,
+        templateHome    = "TEMPLATES/128x64/",
         MenuBox         = { x=15, y=12, w=100, x_offset=36, h_line=8, h_offset=3 },
         SaveBox         = { x=15, y=12, w=100, x_offset=4,  h=30, h_offset=5 },
         NoTelem         = { 30, 55, "No Telemetry", BLINK },
@@ -19,8 +12,7 @@ local supportedRadios =
     },
     ["212x64"]  = 
     {
-        templateHome    = SCRIPT_HOME.."/TEMPLATES/212x64/",
-        resolution      = lcdResolution.low,
+        templateHome    = "TEMPLATES/212x64/",
         MenuBox         = { x=40, y=12, w=120, x_offset=36, h_line=8, h_offset=3 },
         SaveBox         = { x=40, y=12, w=120, x_offset=4,  h=30, h_offset=5 },
         NoTelem         = { 70, 55, "No Telemetry", BLINK },
@@ -30,8 +22,8 @@ local supportedRadios =
     },
     ["480x272"] = 
     {
-        templateHome    = SCRIPT_HOME.."/TEMPLATES/480x272/",
-        resolution      = lcdResolution.high,
+        templateHome    = "TEMPLATES/480x272/",
+        highRes         = true,
         MenuBox         = { x=120, y=100, w=200, x_offset=68, h_line=20, h_offset=6 },
         SaveBox         = { x=120, y=100, w=180, x_offset=12, h=60, h_offset=12 },
         NoTelem         = { 192, LCD_H - 28, "No Telemetry", (TEXT_COLOR or 0) + INVERS + BLINK },
@@ -41,8 +33,8 @@ local supportedRadios =
     },
     ["320x480"] = 
     {
-        templateHome    = SCRIPT_HOME.."/TEMPLATES/320x480/",
-        resolution      = lcdResolution.high,
+        templateHome    = "TEMPLATES/320x480/",
+        highRes         = true,
         MenuBox         = { x= (LCD_W -200)/2, y=LCD_H/2, w=200, x_offset=68, h_line=20, h_offset=6 },
         SaveBox         = { x= (LCD_W -200)/2, y=LCD_H/2, w=180, x_offset=12, h=60, h_offset=12 },
         NoTelem         = { LCD_W/2 - 50, LCD_H - 28, "No Telemetry", (TEXT_COLOR or 0) + INVERS + BLINK },
@@ -52,7 +44,6 @@ local supportedRadios =
     },
 }
 
-local ver, rad, maj, min, rev = getVersion()
 local radio = supportedRadios[tostring(LCD_W) .. "x" .. tostring(LCD_H)]
 
 if not radio then

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -21,27 +21,25 @@ local uiMsp =
 
 local uiState = uiStatus.init
 local pageState = pageStatus.display
-local requestTimeout = 80 -- 800ms request timeout
+local requestTimeout = 80
 local currentPage = 1
 local currentField = 1
 local saveTS = 0
-local saveTimeout = 0
+local saveTimeout = protocol.saveTimeout
 local saveRetries = 0
-local saveMaxRetries = 0
-local popupMenuActive = false
+local saveMaxRetries = protocol.saveMaxRetries
+local popupMenuActive = 1
 local killEnterBreak = 0
 local pageScrollY = 0
 local mainMenuScrollY = 0
-local PageFiles = nil
-local Page = nil
-local init = nil
+local PageFiles, Page, init
 
 local backgroundFill = TEXT_BGCOLOR or ERASE
 local foregroundColor = LINE_COLOR or SOLID
 
 local globalTextOptions = TEXT_COLOR or 0
 
-local function saveSettings(new)
+local function saveSettings()
     if Page.values then
         local payload = Page.values
         if Page.preSave then
@@ -54,8 +52,6 @@ local function saveSettings(new)
         else
             pageState = pageStatus.saving
             saveRetries = 0
-            saveMaxRetries = protocol.saveMaxRetries or 2 -- default 2
-            saveTimeout = protocol.saveTimeout or 150     -- default 1.5s
         end
     end
 end
@@ -77,54 +73,33 @@ local function eepromWrite()
 end
 
 local popupMenuList = {
-    {
-        t = "save page",
-        f = saveSettings
-    },
-    {
-        t = "reload",
-        f = invalidatePages
-    },
-    {
-        t = "reboot",
-        f = rebootFc
-    }
+    { t = "save page", f = saveSettings },
+    { t = "reload", f = invalidatePages },
+    { t = "reboot", f = rebootFc },
 }
 
 local function processMspReply(cmd,rx_buf)
-    if cmd == nil or rx_buf == nil then
-        return
-    end
-    if Page == nil then
-        return
-    end
-    if cmd == Page.write then
+    if not Page or not rx_buf then
+    elseif cmd == Page.write then
         if Page.eepromWrite then
             eepromWrite()
         else
             invalidatePages()
         end
-        return
-    end
-    if cmd == uiMsp.eepromWrite then
+    elseif cmd == uiMsp.eepromWrite then
         if Page.reboot then
             rebootFc()
         end
         invalidatePages()
-        return
-    end
-    if cmd ~= Page.read then
-        return
-    end
-    if #(rx_buf) > 0 then
+    elseif cmd == Page.read and #rx_buf > 0 then
         Page.values = rx_buf
-        for i=1,#(Page.fields) do
-            if (#(Page.values) or 0) >= Page.minBytes then
+        for i=1,#Page.fields do
+            if #Page.values >= Page.minBytes then
                 local f = Page.fields[i]
                 if f.vals then
-                    f.value = 0;
-                    for idx=1, #(f.vals) do
-                        local raw_val = (Page.values[f.vals[idx]] or 0)
+                    f.value = 0
+                    for idx=1, #f.vals do
+                        local raw_val = Page.values[f.vals[idx]] or 0
                         raw_val = bit32.lshift(raw_val, (idx-1)*8)
                         f.value = bit32.bor(f.value, raw_val)
                     end
@@ -152,14 +127,13 @@ function clipValue(val,min,max)
 end
 
 local function incPage(inc)
-    currentPage = incMax(currentPage, inc, #(PageFiles))
-    Page = nil
+    currentPage = incMax(currentPage, inc, #PageFiles)
     currentField = 1
-    collectgarbage()
+    invalidatePages()
 end
 
 local function incField(inc)
-    currentField = clipValue(currentField + inc, 1, #(Page.fields))
+    currentField = clipValue(currentField + inc, 1, #Page.fields)
 end
 
 local function incMainMenu(inc)
@@ -167,33 +141,32 @@ local function incMainMenu(inc)
 end
 
 local function incPopupMenu(inc)
-    popupMenuActive = clipValue(popupMenuActive + inc, 1, #(popupMenuList))
+    popupMenuActive = clipValue(popupMenuActive + inc, 1, #popupMenuList)
 end
 
 local function requestPage()
-    if Page.read and ((Page.reqTS == nil) or (Page.reqTS + requestTimeout <= getTime())) then
+    if Page.read and ((not Page.reqTS) or (Page.reqTS + requestTimeout <= getTime())) then
         Page.reqTS = getTime()
         protocol.mspRead(Page.read)
     end
 end
 
-local function drawScreenTitle(screen_title)
-    if radio.resolution == lcdResolution.low then
-        lcd.drawFilledRectangle(0, 0, LCD_W, 10)
-        lcd.drawText(1,1,screen_title,INVERS)
-    else
+local function drawScreenTitle(screenTitle)
+    if radio.highRes then
         lcd.drawFilledRectangle(0, 0, LCD_W, 30, TITLE_BGCOLOR)
-        lcd.drawText(5,5,screen_title, MENU_TITLE_COLOR)
+        lcd.drawText(5,5,screenTitle, MENU_TITLE_COLOR)
+    else
+        lcd.drawFilledRectangle(0, 0, LCD_W, 10)
+        lcd.drawText(1,1,screenTitle,INVERS)
     end
 end
 
 local function drawScreen()
-    local yMinLim = radio.yMinLimit or 0
-    local yMaxLim = radio.yMaxLimit or LCD_H
+    local yMinLim = radio.yMinLimit
+    local yMaxLim = radio.yMaxLimit
     local currentFieldY = Page.fields[currentField].y
-    local screenTitle = Page.title
     local textOptions = radio.textSize + globalTextOptions
-    drawScreenTitle("Betaflight / "..screenTitle)
+    drawScreenTitle("Betaflight / "..Page.title)
     if currentFieldY <= Page.fields[1].y then
         pageScrollY = 0
     elseif currentFieldY - pageScrollY <= yMinLim then
@@ -201,14 +174,15 @@ local function drawScreen()
     elseif currentFieldY - pageScrollY >= yMaxLim then
         pageScrollY = currentFieldY - yMaxLim
     end
-    for i=1,#(Page.labels) do
+    for i=1,#Page.labels do
         local f = Page.labels[i]
-        if (f.y - pageScrollY) >= yMinLim and (f.y - pageScrollY) <= yMaxLim then
-            lcd.drawText(f.x, f.y - pageScrollY, f.t, textOptions)
+        local y = f.y - pageScrollY
+        if y >= yMinLim and y <= yMaxLim then
+            lcd.drawText(f.x, y, f.t, textOptions)
         end
     end
     local val = "---"
-    for i=1,#(Page.fields) do
+    for i=1,#Page.fields do
         local f = Page.fields[i]
         local valueOptions = textOptions
         if i == currentField then
@@ -226,22 +200,23 @@ local function drawScreen()
                 val = f.table[f.value]
             end
         end
-        if (f.y - pageScrollY) >= yMinLim and (f.y - pageScrollY) <= yMaxLim then
+        local y = f.y - pageScrollY
+        if y >= yMinLim and y <= yMaxLim then
             if f.t then
-                lcd.drawText(f.x, f.y - pageScrollY, f.t, textOptions)
+                lcd.drawText(f.x, y, f.t, textOptions)
             end
-            lcd.drawText(f.sp or f.x, f.y - pageScrollY, val, valueOptions)
+            lcd.drawText(f.sp or f.x, y, val, valueOptions)
         end
     end
 end
 
 local function incValue(inc)
     local f = Page.fields[currentField]
-    local scale = (f.scale or 1)
-    local mult = (f.mult or 1)
-    f.value = clipValue(f.value + ((inc*mult)/scale), ((f.min or 0)/scale), ((f.max or 255)/scale))
-    f.value = math.floor((f.value*scale)/mult + 0.5)/(scale/mult)
-    for idx=1, #(f.vals) do
+    local scale = f.scale or 1
+    local mult = f.mult or 1
+    f.value = clipValue(f.value + inc*mult/scale, (f.min or 0)/scale, (f.max or 255)/scale)
+    f.value = math.floor(f.value*scale/mult + 0.5)*mult/scale
+    for idx=1, #f.vals do
         Page.values[f.vals[idx]] = bit32.rshift(math.floor(f.value*scale + 0.5), (idx-1)*8)
     end
     if f.upd and Page.values then
@@ -255,18 +230,18 @@ local function drawPopupMenu()
     local w = radio.MenuBox.w
     local h_line = radio.MenuBox.h_line
     local h_offset = radio.MenuBox.h_offset
-    local h = #(popupMenuList) * h_line + h_offset*2
+    local h = #popupMenuList * h_line + h_offset*2
 
     lcd.drawFilledRectangle(x,y,w,h,backgroundFill)
     lcd.drawRectangle(x,y,w-1,h-1,foregroundColor)
     lcd.drawText(x+h_line/2,y+h_offset,"Menu:",globalTextOptions)
 
     for i,e in ipairs(popupMenuList) do
-        local text_options = globalTextOptions
+        local textOptions = globalTextOptions
         if popupMenuActive == i then
-            text_options = text_options + INVERS
+            textOptions = textOptions + INVERS
         end
-        lcd.drawText(x+radio.MenuBox.x_offset,y+(i-1)*h_line+h_offset,e.t,text_options)
+        lcd.drawText(x+radio.MenuBox.x_offset,y+(i-1)*h_line+h_offset,e.t,textOptions)
     end
 end
 
@@ -274,20 +249,17 @@ local function run_ui(event)
     if uiState == uiStatus.init then
         local yMinLim = radio.yMinLimit
         lcd.clear()
-        drawScreenTitle("Betaflight Config", 0, 0)
+        drawScreenTitle("Betaflight Config")
         lcd.drawText(6, yMinLim, "Initialising")
         if apiVersion == 0 then
-            if not init then
-                init = assert(loadScript(SCRIPT_HOME.."/data_init.lua"))()
-            end
+            init = init or assert(loadScript("data_init.lua"))()
             init()
             return 0
-        else
-            init = nil
-            PageFiles = assert(loadScript(SCRIPT_HOME.."/pages.lua"))()
-            invalidatePages()
-            uiState = uiStatus.mainMenu
         end
+        init = nil
+        PageFiles = assert(loadScript("pages.lua"))()
+        invalidatePages()
+        uiState = uiStatus.mainMenu
     elseif uiState == uiStatus.mainMenu then
         if event == EVT_VIRTUAL_EXIT then
             return 2
@@ -296,15 +268,14 @@ local function run_ui(event)
         elseif event == EVT_VIRTUAL_PREV then
             incMainMenu(-1)
         elseif event == EVT_VIRTUAL_ENTER then
-            pageState = pageStatus.display
             uiState = uiStatus.pages
         end
         lcd.clear()
-        drawScreenTitle("Betaflight Config", 0, 0)
+        drawScreenTitle("Betaflight Config")
         local yMinLim = radio.yMinLimit
         local yMaxLim = radio.yMaxLimit
         local lineSpacing = 10
-        if radio.resolution == lcdResolution.high then
+        if radio.highRes then
             lineSpacing = 25
         end
         local currentFieldY = (currentPage-1)*lineSpacing + yMinLim
@@ -316,29 +287,27 @@ local function run_ui(event)
             mainMenuScrollY = currentFieldY - yMaxLim
         end
         for i=1, #PageFiles do
-            local attr = (currentPage == i and INVERS or 0)
-            if ((i-1)*lineSpacing + yMinLim - mainMenuScrollY) >= yMinLim and ((i-1)*lineSpacing + yMinLim - mainMenuScrollY) <= yMaxLim then
-                lcd.drawText(6, (i-1)*lineSpacing + yMinLim - mainMenuScrollY, PageFiles[i].title, attr)
+            local attr = currentPage == i and INVERS or 0
+            local y = (i-1)*lineSpacing + yMinLim - mainMenuScrollY
+            if y >= yMinLim and y <= yMaxLim then
+                lcd.drawText(6, y, PageFiles[i].title, attr)
             end
         end
     elseif uiState == uiStatus.pages then
-        if (pageState == pageStatus.saving) then
-            if (saveTS + saveTimeout < getTime()) then
+        if pageState == pageStatus.saving then
+            if saveTS + saveTimeout < getTime() then
                 if saveRetries < saveMaxRetries then
                     saveSettings()
                 else
-                    -- max retries reached
                     pageState = pageStatus.display
                     invalidatePages()
                 end
             end
         end
-        -- navigation
         if event == EVT_VIRTUAL_ENTER_LONG then
             popupMenuActive = 1
             killEnterBreak = 1
             pageState = pageStatus.popupMenu
-        -- menu is currently displayed
         elseif pageState == pageStatus.popupMenu then
             if event == EVT_VIRTUAL_EXIT then
                 pageState = pageStatus.display
@@ -354,7 +323,6 @@ local function run_ui(event)
                     popupMenuList[popupMenuActive].f()
                 end
             end
-        -- normal page viewing
         elseif pageState <= pageStatus.display then
             if event == EVT_VIRTUAL_PREV_PAGE then
                 incPage(-1)
@@ -378,7 +346,6 @@ local function run_ui(event)
                 uiState = uiStatus.mainMenu
                 return 0
             end
-        -- editing value
         elseif pageState == pageStatus.editing then
             if event == EVT_VIRTUAL_EXIT or event == EVT_VIRTUAL_ENTER then
                 pageState = pageStatus.display
@@ -388,40 +355,31 @@ local function run_ui(event)
                 incValue(-1)
             end
         end
-        if Page == nil then
-            if #PageFiles == 0 then
-                lcd.clear()
-                lcd.drawText(radio.NoTelem[1], radio.NoTelem[2], "No Pages! API: " .. apiVersion, radio.NoTelem[4])
-                return 1
-            end
-            Page = assert(loadScript(SCRIPT_HOME.."/Pages/"..PageFiles[currentPage].script))()
+        if not Page then
+            Page = assert(loadScript("Pages/"..PageFiles[currentPage].script))()
             collectgarbage()
         end
         if not Page.values and pageState == pageStatus.display then
             requestPage()
         end
         lcd.clear()
-        if TEXT_BGCOLOR then
-            lcd.drawFilledRectangle(0, 0, LCD_W, LCD_H, TEXT_BGCOLOR)
-        end
         drawScreen()
         if pageState == pageStatus.popupMenu then
             drawPopupMenu()
         elseif pageState == pageStatus.saving then
+            local saveMsg = "Saving..."
+            if saveRetries > 0 then
+                saveMsg = "Retrying"
+            end
             lcd.drawFilledRectangle(radio.SaveBox.x,radio.SaveBox.y,radio.SaveBox.w,radio.SaveBox.h,backgroundFill)
             lcd.drawRectangle(radio.SaveBox.x,radio.SaveBox.y,radio.SaveBox.w,radio.SaveBox.h,SOLID)
-            if saveRetries <= 0 then
-                lcd.drawText(radio.SaveBox.x+radio.SaveBox.x_offset,radio.SaveBox.y+radio.SaveBox.h_offset,"Saving...",DBLSIZE + BLINK + (globalTextOptions))
-            else
-                lcd.drawText(radio.SaveBox.x+radio.SaveBox.x_offset,radio.SaveBox.y+radio.SaveBox.h_offset,"Retrying",DBLSIZE + (globalTextOptions))
-            end
+            lcd.drawText(radio.SaveBox.x+radio.SaveBox.x_offset,radio.SaveBox.y+radio.SaveBox.h_offset,saveMsg,DBLSIZE + globalTextOptions)
         end
     end
-    -- process send queue
-    mspProcessTxQ()
     if protocol.rssi() == 0 then
         lcd.drawText(radio.NoTelem[1],radio.NoTelem[2],radio.NoTelem[3],radio.NoTelem[4])
     end
+    mspProcessTxQ()
     processMspReply(mspPollReply())
     return 0
 end

--- a/src/SCRIPTS/FUNCTIONS/bfbkgd.lua
+++ b/src/SCRIPTS/FUNCTIONS/bfbkgd.lua
@@ -1,8 +1,8 @@
-SCRIPT_HOME = "/SCRIPTS/BF"
+chdir("/SCRIPTS/BF")
 apiVersion = 0
-protocol = assert(loadScript(SCRIPT_HOME.."/protocols.lua"))()
+protocol = assert(loadScript("protocols.lua"))()
 assert(loadScript(protocol.transport))()
-assert(loadScript(SCRIPT_HOME.."/MSP/common.lua"))()
-local background = assert(loadScript(SCRIPT_HOME.."/background.lua"))()
+assert(loadScript("MSP/common.lua"))()
+local background = assert(loadScript("background.lua"))()
 
 return { run=background }

--- a/src/SCRIPTS/FUNCTIONS/pids.lua
+++ b/src/SCRIPTS/FUNCTIONS/pids.lua
@@ -1,6 +1,6 @@
-SCRIPT_HOME = "/SCRIPTS/BF"
+chdir("/SCRIPTS/BF")
 
-assert(loadScript(SCRIPT_HOME.."/MSP/messages.lua"))()
+assert(loadScript("MSP/messages.lua"))()
 
 local msg_p = {
   intro = "p.wav",

--- a/src/SCRIPTS/TOOLS/bf.lua
+++ b/src/SCRIPTS/TOOLS/bf.lua
@@ -1,14 +1,14 @@
 local toolName = "TNS|Betaflight setup|TNE"
-SCRIPT_HOME = "/SCRIPTS/BF"
+chdir("/SCRIPTS/BF")
 
 apiVersion = 0
 
-protocol = assert(loadScript(SCRIPT_HOME.."/protocols.lua"))()
-radio = assert(loadScript(SCRIPT_HOME.."/radios.lua"))()
+protocol = assert(loadScript("protocols.lua"))()
+radio = assert(loadScript("radios.lua"))()
 
 assert(loadScript(protocol.transport))()
-assert(loadScript(SCRIPT_HOME.."/MSP/common.lua"))()
+assert(loadScript("MSP/common.lua"))()
 
-local run_ui = assert(loadScript(SCRIPT_HOME.."/ui.lua"))()
+local run_ui = assert(loadScript("ui.lua"))()
 
 return { run=run_ui }


### PR DESCRIPTION
A number of small savings that add up to 1-1.5KB.

lcdResolution/radio.resolution removed. Use highRes bool for high resolution LCDs instead.

SCRIPT_HOME removed. Use chdir("/SCRIPTS/BF") instead.

Removed some unused/unnecessary code/variables.

Made some changes to reduce the size of ui.lua. Removed unnecessary paranthesis, newlines, indents. Also removed comments where they aren't really needed.  Reducing the size of a file helps with on device compilation. ui.lua size reduced by approximately 1.5KB.