### PR TITLE
Compile script

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -16,20 +16,31 @@ if [ ${#MANIFEST[@]} -eq 0 ]; then
     exit 1
 fi
 
+SCRIPTS_LUA=obj/SCRIPTS/BF/COMPILE/scripts.lua
+
+echo 'local scripts = {' >> $SCRIPTS_LUA
+for f in ${MANIFEST[@]};
+do
+    echo '    ''"'${f/\obj/}'",' >> $SCRIPTS_LUA
+done
+echo '}' >> $SCRIPTS_LUA
+echo 'return scripts[...]' >> $SCRIPTS_LUA
+
+MANIFEST+=($SCRIPTS_LUA);
+
 for f in ${MANIFEST[@]};
 do
     SRC_NAME=$f
-    OBJ_NAME=$(dirname ${f})/$(basename ${f} .lua).luac
-    echo -e "Compiling file \e[1m${SRC_NAME}\e[21m..."
-    luac -s -o ${OBJ_NAME} ${SRC_NAME}
+    echo -e "Testing file \e[1m${SRC_NAME}\e[21m..."
+    luac -p ${SRC_NAME}
     _fail=$?
     if [[ $_fail -ne 0 ]]; then
         LAST_FAILURE=$_fail
-        echo -e "\e[1m\e[39m[\e[31mBUILD FAILED\e[39m]\e[21m Compilation error in file ${SRC_NAME}\e[1m"
+        echo -e "\e[1m\e[39m[\e[31mBUILD FAILED\e[39m]\e[21m Error in file ${SRC_NAME}\e[1m"
     fi
 done
 
 if [[ $LAST_FAILURE -eq 0 ]]; then
-    echo -e "\e[1m\e[39m[\e[32mTEST SUCCESSFUL\e[39m]\e[21m All lua files built successfully!"
+    echo -e "\e[1m\e[39m[\e[32mTEST SUCCESSFUL\e[39m]\e[21m"
 fi
 exit $LAST_FAILURE

--- a/src/SCRIPTS/BF/COMPILE/compile.lua
+++ b/src/SCRIPTS/BF/COMPILE/compile.lua
@@ -1,0 +1,21 @@
+local i = 1
+
+local function compile()
+    local script = assert(loadScript("COMPILE/scripts.lua"))(i)
+    collectgarbage()
+    i = i + 1
+    if script then
+        lcd.clear()
+        lcd.drawText(2, 2, "Compiling...", SMLSIZE)
+        lcd.drawText(2, 22, script, SMLSIZE)
+        assert(loadScript(script, 'c'))
+        collectgarbage()
+        return 0
+    end
+    local file = io.open("COMPILE/scripts_compiled.lua", 'w')
+    io.write(file, "return true")
+    io.close(file)
+    return 1
+end
+
+return compile

--- a/src/SCRIPTS/BF/COMPILE/scripts_compiled.lua
+++ b/src/SCRIPTS/BF/COMPILE/scripts_compiled.lua
@@ -1,0 +1,1 @@
+return false

--- a/src/SCRIPTS/TOOLS/bf.lua
+++ b/src/SCRIPTS/TOOLS/bf.lua
@@ -3,12 +3,17 @@ chdir("/SCRIPTS/BF")
 
 apiVersion = 0
 
-protocol = assert(loadScript("protocols.lua"))()
-radio = assert(loadScript("radios.lua"))()
+local run = nil
+local scriptsCompiled = assert(loadScript("COMPILE/scripts_compiled.lua"))()
 
-assert(loadScript(protocol.transport))()
-assert(loadScript("MSP/common.lua"))()
+if scriptsCompiled then
+    protocol = assert(loadScript("protocols.lua"))()
+    radio = assert(loadScript("radios.lua"))()
+    assert(loadScript(protocol.transport))()
+    assert(loadScript("MSP/common.lua"))()
+    run = assert(loadScript("ui.lua"))()
+else
+    run = assert(loadScript("COMPILE/compile.lua"))()
+end
 
-local run_ui = assert(loadScript("ui.lua"))()
-
-return { run=run_ui }
+return { run=run }


### PR DESCRIPTION
Adds a script that compiles all Betaflight lua files the first time bf.lua is executed.
build.sh has been repurposed to create a file containing a table with the files to be compiled. The .lua files are tested for errors using luac -p. No .luac files are created.

As discussed in https://github.com/betaflight/betaflight-tx-lua-scripts/issues/281 the main memory issue we have now is running out of memory when compiling the betaflight lua scripts on the TX. OpenTX uses a modified version of LUA 5.2.2 with lua tiny RAM applied. This means that precompiled scripts will not work unless they are created with a version of lua that has had the same mod applied. 

I believe the problem with on device compilation is that we're trying to load too many files in one lua cycle(bf.lua). The solution is to use a compile script that loads and compiles one file each lua cycle.

```compile.lua``` will only run the first time ```bf.lua```is executed. It loads and compiles all files listed in ```scripts.lua``` one by one and exits when done. The next time ```bf.lua``` is executed everything will be as normal. ```compile.lua``` will not run again unless ```scripts_compiled.lua``` is modified or overwritten(new bf lua version).

"Free mem" in OpenTX shows over 40KB after running this(used to be close to 0 or out of memory).




