### PR TITLE
Prevent double compile

### DIFF
--- a/src/SCRIPTS/BF/COMPILE/compile.lua
+++ b/src/SCRIPTS/BF/COMPILE/compile.lua
@@ -15,6 +15,7 @@ local function compile()
     local file = io.open("COMPILE/scripts_compiled.lua", 'w')
     io.write(file, "return true")
     io.close(file)
+    assert(loadScript("COMPILE/scripts_compiled.lua", 'c'))
     return 1
 end
 


### PR DESCRIPTION
Forces a recompile of scripts_compiled.lua after writing to it. This ensures that the .lua and .luac are the same and prevents a potential recompile the next time bf.lua is launched.