### PR TITLE
Add vtx tables download to popup menu

### DIFF
--- a/src/SCRIPTS/BF/ui_init.lua
+++ b/src/SCRIPTS/BF/ui_init.lua
@@ -1,6 +1,13 @@
 local apiVersionReceived = false
-local vtxTablesReceived = loadScript("/BF/VTX/"..model.getInfo().name..".lua")
+local vtxTablesReceived = false
 local data_init, getVtxTables
+local vtxTables = loadScript("/BF/VTX/"..model.getInfo().name..".lua")
+
+if vtxTables and vtxTables() then
+    vtxTablesReceived = true
+    vtxTables = nil
+    collectgarbage()
+end
 
 local function init()
     if apiVersion == 0 then


### PR DESCRIPTION
Deletes the contents of the .lua file containing vtx tables for the selected model and downloads them again.
The menu item is only available for firmwares supporting vtx tables.