### PR TITLE
Fix "Radio not supported" message

### DIFF
--- a/src/SCRIPTS/BF/protocols.lua
+++ b/src/SCRIPTS/BF/protocols.lua
@@ -32,10 +32,6 @@ local function getProtocol()
     end
 end
 
-local protocol = getProtocol()
-
-if not protocol then
-    error("Telemetry protocol not supported!")
-end
+local protocol = assert(getProtocol(), "Telemetry protocol not supported!")
 
 return protocol

--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -44,10 +44,7 @@ local supportedRadios =
     },
 }
 
-local radio = supportedRadios[tostring(LCD_W) .. "x" .. tostring(LCD_H)]
-
-if not radio then
-    error("Radio not supported: "..rad)
-end
+local resolution = LCD_W.."x"..LCD_H
+local radio = assert(supportedRadios[resolution], resolution.." not supported")
 
 return radio


### PR DESCRIPTION
Now it displays an error message if the resolution is not supported. 
Replaced the use of `error` with `assert`.