### PR TITLE
Dynamic idle and rpm harmonics reboot

### DIFF
--- a/src/SCRIPTS/BF/PAGES/filters2.lua
+++ b/src/SCRIPTS/BF/PAGES/filters2.lua
@@ -43,4 +43,11 @@ return {
     minBytes    = 5,
     labels      = labels,
     fields      = fields,
+    postLoad = function(self)
+        self.rpmHarmonics = self.values[44]
+    end,
+    preSave = function(self)
+        self.reboot = self.values[44] == 0 and self.rpmHarmonics ~= 0
+        return self.values
+    end,
 }

--- a/src/SCRIPTS/BF/PAGES/pid_advanced.lua
+++ b/src/SCRIPTS/BF/PAGES/pid_advanced.lua
@@ -69,4 +69,11 @@ return {
     minBytes    = 8,
     labels      = labels,
     fields      = fields,
+    postLoad = function(self)
+        self.dynamicIdle = self.values[50]
+    end,
+    preSave = function(self)
+        self.reboot = self.values[50] ~= self.dynamicIdle
+        return self.values
+    end,
 }


### PR DESCRIPTION
This commit adds a reboot after changing the dynamic idle value and after disabling the rpm filter by setting harmonics to 0.

Rpm filter has to be enabled for dynamic idle to work. Disabling the rpm filter will also disable dynamic idle. Reboot needed for dynamic idle change to take effect.
