### PR TITLE
Remove Gyro/PID loop

### DIFF
--- a/src/SCRIPTS/BF/PAGES/pwm.lua
+++ b/src/SCRIPTS/BF/PAGES/pwm.lua
@@ -38,8 +38,10 @@ if apiVersion >= 1.031 and apiVersion <= 1.040 then
 end
 
 if apiVersion >= 1.016 then
-    fields[#fields + 1] = { t = "Gyro Update",     x = x,      y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 32, vals = { 1 }, table = {}, upd = function(self) self.updatePidRateTable(self) end }
-    fields[#fields + 1] = { t = "PID Loop",        x = x,      y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 16, vals = { 2 }, table = {} }
+    if apiVersion <= 1.042 then
+        fields[#fields + 1] = { t = "Gyro Update", x = x,      y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 32, vals = { 1 }, table = {}, upd = function(self) self.updatePidRateTable(self) end }
+        fields[#fields + 1] = { t = "PID Loop",    x = x,      y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 16, vals = { 2 }, table = {} }
+    end
     fields[#fields + 1] = { t = "Protocol",        x = x,      y = inc.y(lineSpacing), sp = x + sp, min = 0, max = #escProtocols, vals = { 4 }, table = escProtocols }
     fields[#fields + 1] = { t = "Unsynced PWM",    x = x,      y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 3 }, table = { [0] = "OFF", "ON" } }
     fields[#fields + 1] = { t = "PWM Frequency",   x = x,      y = inc.y(lineSpacing), sp = x + sp, min = 200, max = 32000, vals = { 5, 6 }, }


### PR DESCRIPTION
for Betaflight 4.2 and up. With gyro native rate sampling these numbers will only make sense for gyros with 8kHz sampling rate.