### PR TITLE
Craft name for vtx tables

### DIFF
--- a/src/SCRIPTS/BF/PAGES/vtx.lua
+++ b/src/SCRIPTS/BF/PAGES/vtx.lua
@@ -1,7 +1,6 @@
-local md = model.getInfo();
-local vtx_tables = loadScript("/BF/VTX/"..md.name..".lua")
-if vtx_tables then
-    vtx_tables = vtx_tables()
+local vtx_tables
+if apiVersion >= 1.042 then
+    vtx_tables = assert(loadScript("/BF/VTX/"..mcuId..".lua"))()
 else
     vtx_tables = assert(loadScript("/BF/VTX/vtx_defaults.lua"))()
 end

--- a/src/SCRIPTS/BF/mcu_id.lua
+++ b/src/SCRIPTS/BF/mcu_id.lua
@@ -1,0 +1,37 @@
+local MSP_UID = 160
+
+local MCUIdReceived = false
+
+local lastRunTS = 0
+local INTERVAL = 100
+
+local function processMspReply(cmd, payload)
+    if cmd == MSP_UID then
+        local i = 1
+        local id = ""
+        for j = 1, 3 do
+            local s = ""
+            for k = 1, 4 do
+                s = string.format("%02x", payload[i])..s
+                i = i + 1
+            end
+            id = id..s
+        end
+        mcuId = id
+        MCUIdReceived = true
+    end
+end
+
+local function getMCUId()
+    if lastRunTS + INTERVAL < getTime() then
+        lastRunTS = getTime()
+        if not MCUIdReceived then
+            protocol.mspRead(MSP_UID)
+        end
+    end
+    mspProcessTxQ()
+    processMspReply(mspPollReply())
+    return MCUIdReceived
+end
+
+return getMCUId

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -76,7 +76,7 @@ local function getVtxTables()
     uiState = uiStatus.init
     PageFiles = nil
     invalidatePages()
-    io.close(io.open("/BF/VTX/"..model.getInfo().name..".lua", 'w'))
+    io.close(io.open("/BF/VTX/"..mcuId..".lua", 'w'))
     return 0
 end
 

--- a/src/SCRIPTS/BF/ui_init.lua
+++ b/src/SCRIPTS/BF/ui_init.lua
@@ -1,13 +1,6 @@
 local apiVersionReceived = false
 local vtxTablesReceived = false
-local data_init, getVtxTables
-local vtxTables = loadScript("/BF/VTX/"..model.getInfo().name..".lua")
-
-if vtxTables and vtxTables() then
-    vtxTablesReceived = true
-    vtxTables = nil
-    collectgarbage()
-end
+local data_init, getVtxTables, getMCUId
 
 local function init()
     if apiVersion == 0 then
@@ -18,6 +11,18 @@ local function init()
         data_init = nil
         apiVersionReceived = true
         collectgarbage()
+    elseif apiVersion >= 1.042 and not mcuId then
+        lcd.drawText(6, radio.yMinLimit, "Waiting for device ID")
+        getMCUId = getMCUId or assert(loadScript("mcu_id.lua"))()
+        if getMCUId() then
+            getMCUId = nil
+            local vtxTables = loadScript("/BF/VTX/"..mcuId..".lua")
+            if vtxTables and vtxTables() then
+                vtxTablesReceived = true
+                vtxTables = nil
+            end
+            collectgarbage()
+        end
     elseif apiVersion >= 1.042 and not vtxTablesReceived then
         lcd.drawText(6, radio.yMinLimit, "Downloading VTX Tables")
         getVtxTables = getVtxTables or assert(loadScript("vtx_tables.lua"))()
@@ -29,7 +34,7 @@ local function init()
     else
         return true
     end
-    return apiVersionReceived and vtxTablesReceived
+    return apiVersionReceived and vtxTablesReceived and mcuId
 end
 
 return init

--- a/src/SCRIPTS/BF/vtx_tables.lua
+++ b/src/SCRIPTS/BF/vtx_tables.lua
@@ -82,7 +82,7 @@ local function getVtxTables()
         end
     end
     if vtxTablesReceived then
-        local f = io.open("/BF/VTX/"..model.getInfo().name..".lua", 'w')
+        local f = io.open("/BF/VTX/"..mcuId..".lua", 'w')
         io.write(f, "return {", "\n")
         io.write(f, "    frequencyTable = {", "\n")
         for i = 1, #frequencyTable do
@@ -109,7 +109,7 @@ local function getVtxTables()
         io.write(f, powerString, "\n")
         io.write(f, "}", "\n")
         io.close(f)
-        assert(loadScript("/BF/VTX/"..model.getInfo().name..".lua", 'c'))
+        assert(loadScript("/BF/VTX/"..mcuId..".lua", 'c'))
     end
     mspProcessTxQ()
     processMspReply(mspPollReply())

--- a/src/SCRIPTS/TOOLS/bf.lua
+++ b/src/SCRIPTS/TOOLS/bf.lua
@@ -2,6 +2,7 @@ local toolName = "TNS|Betaflight setup|TNE"
 chdir("/SCRIPTS/BF")
 
 apiVersion = 0
+mcuId = nil
 
 local run = nil
 local scriptsCompiled = assert(loadScript("COMPILE/scripts_compiled.lua"))()


### PR DESCRIPTION
Reads craft name from MSP and uses that name to store the vtx tables. If the craft name is empty it falls back on using the transmitter model name as before. This should solve the problem of using an incorrect vtx table when people have many different crafts with different vtx hardware under the same model name.