### PR TITLE
128x96 support

### DIFF
--- a/src/SCRIPTS/BF/TEMPLATES/128x96/default_template.lua
+++ b/src/SCRIPTS/BF/TEMPLATES/128x96/default_template.lua
@@ -1,0 +1,7 @@
+return {
+    margin       = 2,
+    indent       = 6,
+    lineSpacing  = 8,
+    listSpacing  = { line = 8, field = 88 },
+    tableSpacing = { row = 10, col = 30, header = 8 },
+}

--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -27,6 +27,33 @@ local supportedRadios =
             },
         },
     },
+    ["128x96"]  = 
+    {
+        msp = {
+            templateHome    = "TEMPLATES/128x96/",
+            MenuBox         = { x=15, y=12, w=100, x_offset=36, h_line=8, h_offset=3 },
+            SaveBox         = { x=15, y=12, w=100, x_offset=4,  h=30, h_offset=5 },
+            NoTelem         = { 30, 87, "No Telemetry", BLINK },
+            textSize        = SMLSIZE,
+            yMinLimit       = 12,
+            yMaxLimit       = 84,
+        },
+        cms = {
+            rows = 12,
+            cols = 26,
+            pixelsPerRow = 8,
+            pixelsPerChar = 5,
+            xIndent = 0,
+            yOffset = 0,
+            textSize = SMLSIZE,
+            refresh = {
+                event = EVT_VIRTUAL_ENTER,
+                text = "Refresh: [ENT]",
+                top = 1,
+                left = 64,
+            },
+        },
+    },
     ["212x64"]  = 
     {
         msp = {


### PR DESCRIPTION
Adds support for radios using a 128x96 resolution display.

Specifically the Tango 2. 

Untested but here it is if anyone with a Tango 2 would like to try it
[betaflight-tx-lua-scripts_1.5.0.zip](https://github.com/betaflight/betaflight-tx-lua-scripts/files/5260645/betaflight-tx-lua-scripts_1.5.0.zip)

