### PR TITLE
Rates type support

### DIFF
--- a/src/SCRIPTS/BF/RATETABLES/ACTUAL.lua
+++ b/src/SCRIPTS/BF/RATETABLES/ACTUAL.lua
@@ -1,0 +1,15 @@
+return {
+    labels = { "", "", "ROLL", "PITCH", "YAW", "Cntr", "Sens", "Max", "Rate", "", "Expo" },
+    fields = {
+        { min = 1, max = 200, scale = 0.1 },
+        { min = 1, max = 200, scale = 0.1 },
+        { min = 1, max = 200, scale = 0.1 },
+        { min = 0, max = 200, scale = 0.1 },
+        { min = 0, max = 200, scale = 0.1 },
+        { min = 0, max = 200, scale = 0.1 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 }
+    },
+    defaults = { 200, 200, 200, 670, 670, 670, 0.54, 0.54, 0.54 }
+}

--- a/src/SCRIPTS/BF/RATETABLES/BF.lua
+++ b/src/SCRIPTS/BF/RATETABLES/BF.lua
@@ -1,0 +1,15 @@
+return {
+    labels = { "", "", "ROLL", "PITCH", "YAW", "RC", "Rate", "Super", "Rate", "RC", "Expo" },
+    fields = {
+        { min = 0, max = 255, scale = 100 },
+        { min = 0, max = 255, scale = 100 },
+        { min = 0, max = 255, scale = 100 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 255, scale = 100 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 }
+    },
+    defaults = { 1.0, 1.0, 1.0, 0.7, 0.7, 0.7, 0.0, 0.0, 0.0 }
+}

--- a/src/SCRIPTS/BF/RATETABLES/KISS.lua
+++ b/src/SCRIPTS/BF/RATETABLES/KISS.lua
@@ -1,0 +1,15 @@
+return {
+    labels = { "", "", "ROLL", "PITCH", "YAW", "RC", "Rate", "", "Rate", "RC", "Curve" },
+    fields = {
+        { min = 1, max = 255, scale = 100 },
+        { min = 1, max = 255, scale = 100 },
+        { min = 1, max = 255, scale = 100 },
+        { min = 0, max = 99,  scale = 100 },
+        { min = 0, max = 99,  scale = 100 },
+        { min = 0, max = 99,  scale = 100 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 }
+    },
+    defaults = { 1.0, 1.0, 1.0, 0.7, 0.7, 0.7, 0.0, 0.0, 0.0 }
+}

--- a/src/SCRIPTS/BF/RATETABLES/QUICK.lua
+++ b/src/SCRIPTS/BF/RATETABLES/QUICK.lua
@@ -1,0 +1,15 @@
+return {
+    labels = { "", "", "ROLL", "PITCH", "YAW", "RC", "Rate", "Max", "Rate", "", "Expo" },
+    fields = {
+        { min = 1, max = 255, scale = 100 },
+        { min = 1, max = 255, scale = 100 },
+        { min = 1, max = 255, scale = 100 },
+        { min = 0, max = 200, scale = 0.1 },
+        { min = 0, max = 200, scale = 0.1 },
+        { min = 0, max = 200, scale = 0.1 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 },
+        { min = 0, max = 100, scale = 100 }
+    },
+    defaults = { 1.0, 1.0, 1.0, 670, 670, 670, 0.0, 0.0, 0.0 }
+}

--- a/src/SCRIPTS/BF/RATETABLES/RF.lua
+++ b/src/SCRIPTS/BF/RATETABLES/RF.lua
@@ -1,0 +1,15 @@
+return {
+    labels = { "", "", "ROLL", "PITCH", "YAW", "", "Rate", "", "Acro+", "", "Expo" },
+    fields = {
+        { min = 1, max = 200, scale = 0.1 },
+        { min = 1, max = 200, scale = 0.1 },
+        { min = 1, max = 200, scale = 0.1 },
+        { min = 0, max = 100, scale = 1 },
+        { min = 0, max = 100, scale = 1 },
+        { min = 0, max = 100, scale = 1 },
+        { min = 0, max = 100, scale = 1 },
+        { min = 0, max = 100, scale = 1 },
+        { min = 0, max = 100, scale = 1 }
+    },
+    defaults = { 370, 370, 370, 80, 80, 80, 50, 50, 50 }
+}

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -358,6 +358,9 @@ local function run_ui(event)
             end
         elseif pageState == pageStatus.editing then
             if event == EVT_VIRTUAL_EXIT or event == EVT_VIRTUAL_ENTER then
+                if Page.fields[currentField].postEdit then
+                    Page.fields[currentField].postEdit(Page)
+                end
                 pageState = pageStatus.display
             elseif event == EVT_VIRTUAL_INC or event == EVT_VIRTUAL_INC_REPT then
                 incValue(1)


### PR DESCRIPTION
Adds support for changing rates type.

Works like in the configurator. Changes labels, scaling, min, max, and applies default values for the selected rates type.

For testing: [betaflight-tx-lua-scripts_1.5.0.zip](https://github.com/betaflight/betaflight-tx-lua-scripts/files/5340275/betaflight-tx-lua-scripts_1.5.0.zip)

