### PR TITLE
Accelerometer calibration

### DIFF
--- a/src/SCRIPTS/BF/PAGES/accelerometer.lua
+++ b/src/SCRIPTS/BF/PAGES/accelerometer.lua
@@ -1,0 +1,36 @@
+local template = loadScript(radio.templateHome.."accelerometer.lua")
+if template then
+    template = template()
+else
+    template = assert(loadScript(radio.templateHome.."default_template.lua"))()
+end
+local margin = template.margin
+local indent = template.indent
+local lineSpacing = template.lineSpacing
+local tableSpacing = template.tableSpacing
+local sp = template.listSpacing.field
+local yMinLim = radio.yMinLimit
+local x = margin
+local y = yMinLim - lineSpacing
+local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }
+local labels = {}
+local fields = {}
+
+labels[#labels + 1] = { t = "Make sure the craft is level", x = x, y = inc.y(lineSpacing) }
+labels[#labels + 1] = { t = "and stable, then press",       x = x, y = inc.y(lineSpacing) }
+labels[#labels + 1] = { t = "[ENTER] to calibrate, or",     x = x, y = inc.y(lineSpacing) }
+labels[#labels + 1] = { t = "[EXIT] to cancel.",            x = x, y = inc.y(lineSpacing) }
+fields[#fields + 1] = { x = x, y = inc.y(lineSpacing), value = "", ro = true, onClick = function(self) self.accCal(self) end }
+
+return {
+    write       = 205, -- MSP_ACC_CALIBRATION
+    title       = "Accelerometer",
+    reboot      = false,
+    eepromWrite = false,
+    minBytes    = 0,
+    labels      = labels,
+    fields      = fields,
+    accCal = function(self)
+        protocol.mspRead(self.write)
+    end,
+}

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -16,7 +16,7 @@ local pageStatus =
 local uiMsp =
 {
     reboot = 68,
-    eepromWrite = 250
+    eepromWrite = 250,
 }
 
 local uiState = uiStatus.init
@@ -72,6 +72,13 @@ local function eepromWrite()
     protocol.mspRead(uiMsp.eepromWrite)
 end
 
+local function accCal()
+    invalidatePages()
+    currentField = 1
+    Page = assert(loadScript("Pages/accelerometer.lua"))()
+    collectgarbage()
+end
+
 local function getVtxTables()
     uiState = uiStatus.init
     PageFiles = nil
@@ -85,6 +92,7 @@ local function createPopupMenu()
         { t = "save page", f = saveSettings },
         { t = "reload", f = invalidatePages },
         { t = "reboot", f = rebootFc },
+        { t = "acc cal", f = accCal },
     }
     if apiVersion >= 1.042 then
         popupMenuList[#popupMenuList + 1] = { t = "vtx tables", f = getVtxTables }
@@ -342,6 +350,9 @@ local function run_ui(event)
             elseif event == EVT_VIRTUAL_ENTER then
                 if Page then
                     local f = Page.fields[currentField]
+                    if f.onClick then
+                        f.onClick(Page)
+                    end
                     if Page.values and f.vals and Page.values[f.vals[#f.vals]] and not f.ro then
                         pageState = pageStatus.editing
                     end


### PR DESCRIPTION
Adds a special page to calibrate the accelerometer. The page can be accessed from the menu like this:
![screenshot_x7_20-12-19_11-46-19](https://user-images.githubusercontent.com/41271048/102687562-475a7880-41f0-11eb-8e5b-ef71cc0f4f46.png)
selecting "acc cal" brings up this:
![screenshot_x7_20-12-19_11-46-24](https://user-images.githubusercontent.com/41271048/102687585-622ced00-41f0-11eb-9b36-6063137ec7bc.png)
where [ENTER] is the enter key and [EXIT] is the exit key on the radio. Pressing the enter key will send ```MSP_ACC_CALIBRATION``` to the flight controller. The flight controller will calibrate the accelerometer and send the command back. The page will exit automatically when the response is received.


Fixes #290 