### PR TITLE
Add min dth to GPS rescue page

### DIFF
--- a/src/SCRIPTS/BF/PAGES/rescue.lua
+++ b/src/SCRIPTS/BF/PAGES/rescue.lua
@@ -24,7 +24,10 @@ if apiVersion >= 1.041 then
     fields[#fields + 1] = { t = "Ground Speed",     x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 30, max = 3000, vals = { 7, 8 } }
 
     if apiVersion >= 1.043 then
+        fields[#fields + 1] = { t = "Ascend Rate",  x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 100, max = 2500, vals = { 17, 18 }, scale = 100 }
+        fields[#fields + 1] = { t = "Descend Rate", x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 100, max = 500, vals = { 19, 20 }, scale = 100 }
         fields[#fields + 1] = { t = "Arm w/o fix",  x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 21 }, table = { [0]="OFF","ON"} }
+        fields[#fields + 1] = { t = "Altitude Mode",x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 2, vals = { 22 }, table = { [0]="Maximum", "Fixed", "Current"} }
     end
 
     fields[#fields + 1] = { t = "Sanity Check",     x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 2, vals = { 15 }, table = { [0]="OFF","ON","FS_ONLY"} }

--- a/src/SCRIPTS/BF/PAGES/rescue.lua
+++ b/src/SCRIPTS/BF/PAGES/rescue.lua
@@ -32,6 +32,10 @@ if apiVersion >= 1.041 then
     fields[#fields + 1] = { t = "Min",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1000, max = 2000, vals = { 9, 10 } }
     fields[#fields + 1] = { t = "Hover",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1000, max = 2000, vals = { 13, 14 } }
     fields[#fields + 1] = { t = "Max",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1000, max = 2000, vals = { 11, 12 } }
+
+    if apiVersion >= 1.044 then
+        fields[#fields + 1] = { t = "Min Dth",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 50, max = 1000, vals = { 23, 24 } }
+    end
 end
 
 return {


### PR DESCRIPTION
Added gps rescue minimum distance to home to GPS rescue page.

Firmware PR: https://github.com/betaflight/betaflight/pull/10684

Closes https://github.com/betaflight/betaflight-tx-lua-scripts/issues/327


Edit: Added ascend/descend rate and altitude mode. They are in the configurator but were missing from the lua scripts.
