### PR TITLE
Popup improvements

### DIFF
--- a/src/SCRIPTS/BF/CONFIRM/acc_cal.lua
+++ b/src/SCRIPTS/BF/CONFIRM/acc_cal.lua
@@ -1,4 +1,4 @@
-local template = loadScript(radio.templateHome.."accelerometer.lua")
+local template = loadScript(radio.templateHome.."acc_cal.lua")
 if template then
     template = template()
 else
@@ -20,17 +20,11 @@ labels[#labels + 1] = { t = "Make sure the craft is level", x = x, y = inc.y(lin
 labels[#labels + 1] = { t = "and stable, then press",       x = x, y = inc.y(lineSpacing) }
 labels[#labels + 1] = { t = "[ENTER] to calibrate, or",     x = x, y = inc.y(lineSpacing) }
 labels[#labels + 1] = { t = "[EXIT] to cancel.",            x = x, y = inc.y(lineSpacing) }
-fields[#fields + 1] = { x = x, y = inc.y(lineSpacing), value = "", ro = true, onClick = function(self) self.accCal(self) end }
+fields[#fields + 1] = { x = x, y = inc.y(lineSpacing), value = "", ro = true }
 
 return {
-    write       = 205, -- MSP_ACC_CALIBRATION
-    title       = "Accelerometer",
-    reboot      = false,
-    eepromWrite = false,
-    minBytes    = 0,
-    labels      = labels,
-    fields      = fields,
-    accCal = function(self)
-        protocol.mspRead(self.write)
-    end,
+    title  = "Accelerometer",
+    labels = labels,
+    fields = fields,
+    init   = assert(loadScript("acc_cal.lua"))(),
 }

--- a/src/SCRIPTS/BF/CONFIRM/vtx_tables.lua
+++ b/src/SCRIPTS/BF/CONFIRM/vtx_tables.lua
@@ -1,0 +1,29 @@
+local template = loadScript(radio.templateHome.."vtx_tables.lua")
+if template then
+    template = template()
+else
+    template = assert(loadScript(radio.templateHome.."default_template.lua"))()
+end
+local margin = template.margin
+local indent = template.indent
+local lineSpacing = template.lineSpacing
+local tableSpacing = template.tableSpacing
+local sp = template.listSpacing.field
+local yMinLim = radio.yMinLimit
+local x = margin
+local y = yMinLim - lineSpacing
+local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }
+local labels = {}
+local fields = {}
+
+labels[#labels + 1] = { t = "Download VTX tables? Press", x = x, y = inc.y(lineSpacing) }
+labels[#labels + 1] = { t = "[ENTER] to download, or",    x = x, y = inc.y(lineSpacing) }
+labels[#labels + 1] = { t = "[EXIT] to cancel.",          x = x, y = inc.y(lineSpacing) }
+fields[#fields + 1] = { x = x, y = inc.y(lineSpacing), value = "", ro = true }
+
+return {
+    title  = "VTX Tables",
+    labels = labels,
+    fields = fields,
+    init   = assert(loadScript("vtx_tables.lua"))(),
+}

--- a/src/SCRIPTS/BF/acc_cal.lua
+++ b/src/SCRIPTS/BF/acc_cal.lua
@@ -1,0 +1,24 @@
+local MSP_ACC_CALIBRATION = 205
+local accCalibrated = false
+local lastRunTS = 0
+local INTERVAL = 500
+
+local function processMspReply(cmd,rx_buf)
+    if cmd == MSP_ACC_CALIBRATION then
+        accCalibrated = true
+    end
+end
+
+local function accCal()
+    if lastRunTS == 0 or lastRunTS + INTERVAL < getTime() then
+        lastRunTS = getTime()
+        if not accCalibrated then
+            protocol.mspRead(MSP_ACC_CALIBRATION)
+        end
+    end
+    mspProcessTxQ()
+    processMspReply(mspPollReply())
+    return accCalibrated
+end
+
+return { f = accCal, t = "Calibrating Accelerometer" }

--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -1,26 +1,14 @@
-local sensorId = -1
 local dataInitialised = false
 local data_init = nil
 local rssiEnabled = true
 local rssiTask = nil
 
-local function getSensorValue()
-    if sensorId == -1 then
-        local sensor = getFieldInfo(protocol.stateSensor)
-        if type(sensor) == "table" then
-            sensorId = sensor['id'] or -1
-        end
-    end
-    return getValue(sensorId)
-end
-
-local function modelActive(sensorValue)
-    return type(sensorValue) == "number" and sensorValue > 0
+local function modelActive()
+    return getValue(protocol.stateSensor) > 0
 end
 
 local function run_bg()
-    local sensorValue = getSensorValue()
-    if modelActive(sensorValue) then
+    if modelActive() then
         -- Send data when the telemetry connection is available
         -- assuming when sensor value higher than 0 there is an telemetry connection
         if not dataInitialised then
@@ -28,7 +16,7 @@ local function run_bg()
                 data_init = assert(loadScript("data_init.lua"))()
             end
 
-            dataInitialised = data_init()
+            dataInitialised = data_init.f()
 
             if dataInitialised then
                 data_init = nil

--- a/src/SCRIPTS/BF/data_init.lua
+++ b/src/SCRIPTS/BF/data_init.lua
@@ -63,4 +63,4 @@ local function init()
     return apiVersionReceived and timeIsSet
 end
 
-return init
+return { f = init, t = "Waiting for API version" }

--- a/src/SCRIPTS/BF/mcu_id.lua
+++ b/src/SCRIPTS/BF/mcu_id.lua
@@ -34,4 +34,4 @@ local function getMCUId()
     return MCUIdReceived
 end
 
-return getMCUId
+return { f = getMCUId, t = "Waiting for device ID" }

--- a/src/SCRIPTS/BF/vtx_tables.lua
+++ b/src/SCRIPTS/BF/vtx_tables.lua
@@ -116,4 +116,4 @@ local function getVtxTables()
     return vtxTablesReceived
 end
 
-return getVtxTables
+return { f = getVtxTables, t = "Downloading VTX Tables" }


### PR DESCRIPTION
Some improvements to the popup menu and the confirmation page functionality.

The popup menu can now be opened by long pressing enter on the main menu and on the page view. The menu is now created on demand so that we can populate it with different items depending on the `uiState` we're in.

Now we can do this:
![screenshot_x7_21-05-09_21-17-41](https://user-images.githubusercontent.com/41271048/117584318-92781800-b10c-11eb-8f88-e76b9b663b39.png)

and this:
![screenshot_x7_21-05-09_21-17-52](https://user-images.githubusercontent.com/41271048/117584337-a6bc1500-b10c-11eb-840a-d01102604b6f.png)

Made a new state `uiStatus.confirm` for the confirmation dialogue.
Added a confirmation dialogue for downloading vtx tables too.
![screenshot_x7_21-05-09_21-38-58](https://user-images.githubusercontent.com/41271048/117584760-ff8cad00-b10e-11eb-9c29-b0aca9e4e3a9.png)

Changed the behaviour a little so that after calibrating the accelerometer or downloading vtx tables the script will return to the previous `uiState` on completion. This just makes the user experience a little nicer. The old behaviour was that it returned to the main menu. 

Removed `getSensorValue` and simplified `modelActive` a lot. This code was a lot more complicated than it had to be. 

Moved all lcd writing to `ui.lua`. `ui_init.lua` and all the functions called by it will now return a table containing a function and a string.

Test version here:
[betaflight-tx-lua-scripts_1.5.0.zip](https://github.com/betaflight/betaflight-tx-lua-scripts/files/6448269/betaflight-tx-lua-scripts_1.5.0.zip)
