### PR TITLE
Use getRSSI() for telemetry detection

### DIFF
--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -3,12 +3,8 @@ local timeIsSet = false
 local getApiVersion, setRtc, rssiTask
 local rssiEnabled = true
 
-local function modelActive()
-    return getValue(protocol.stateSensor) > 0
-end
-
 local function run_bg()
-    if modelActive() then
+    if getRSSI() > 0 then
         -- Send data when the telemetry connection is available
         -- assuming when sensor value higher than 0 there is an telemetry connection
         if not apiVersionReceived then

--- a/src/SCRIPTS/BF/protocols.lua
+++ b/src/SCRIPTS/BF/protocols.lua
@@ -3,8 +3,6 @@ local supportedProtocols =
     smartPort =
     {
         mspTransport    = "MSP/sp.lua",
-        rssi            = function() return getValue("RSSI") end,
-        stateSensor     = "Tmp1",
         push            = sportTelemetryPush,
         maxTxBufferSize = 6,
         maxRxBufferSize = 6,
@@ -16,8 +14,6 @@ local supportedProtocols =
     {
         mspTransport    = "MSP/crsf.lua",
         cmsTransport    = "CMS/crsf.lua",
-        rssi            = function() return getValue("TQly") end,
-        stateSensor     = "1RSS",
         push            = crossfireTelemetryPush,
         maxTxBufferSize = 8,
         maxRxBufferSize = 58,

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -408,7 +408,7 @@ local function run_ui(event)
             prevUiState = nil
         end
     end
-    if protocol.rssi() == 0 then
+    if getRSSI() == 0 then
         lcd.drawText(radio.NoTelem[1],radio.NoTelem[2],radio.NoTelem[3],radio.NoTelem[4])
     end
     mspProcessTxQ()

--- a/src/SCRIPTS/BF/ui_init.lua
+++ b/src/SCRIPTS/BF/ui_init.lua
@@ -5,12 +5,8 @@ local boardInfoReceived = false
 local getApiVersion, getVtxTables, getMCUId, getBoardInfo
 local returnTable = { f = nil, t = "" }
 
-local function modelActive()
-    return getValue(protocol.stateSensor) > 0
-end
-
 local function init()
-    if not modelActive() then
+    if getRSSI() == 0 then
         returnTable.t = "Waiting for connection"
     elseif not apiVersionReceived then
         getApiVersion = getApiVersion or assert(loadScript("api_version.lua"))()


### PR DESCRIPTION
Use ```getRSSI()``` for telemetry detection.
Removes the state sensors and protocol specific rssi functions. 

There are several systems using the crossfire protocol, but it's possible that not all have the "1RSS" sensor we use for detecting crossfire telemetry.

Tested and confirmed working with Frsky, TBS Tracer and Express LRS.

Fixes https://github.com/betaflight/betaflight-tx-lua-scripts/issues/405 and https://github.com/betaflight/betaflight-tx-lua-scripts/issues/387