### PR TITLE
Update MSP protocol

### DIFF
--- a/src/SCRIPTS/BF/MSP/sp.lua
+++ b/src/SCRIPTS/BF/MSP/sp.lua
@@ -7,9 +7,11 @@ local REPLY_FRAME_ID   = 0x32
 local lastSensorId, lastFrameId, lastDataId, lastValue
 
 protocol.mspSend = function(payload)
-    local dataId = payload[1] + bit32.lshift(payload[2],8)
-    local value = payload[3] + bit32.lshift(payload[4],8)
-        + bit32.lshift(payload[5],16) + bit32.lshift(payload[6],24)
+    local dataId = payload[1] + bit32.lshift(payload[2], 8)
+    local value = 0
+    for i = 3, #payload do
+        value = value + bit32.lshift(payload[i], (i - 3) * 8)
+    end
     return protocol.push(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
 end
 


### PR DESCRIPTION
for compatibility with https://github.com/betaflight/betaflight/pull/11112.

The changes are:
- Reads version number from status byte
- Updated error bit mask. It's now bit 7
- Read command from payload based on version number
- Check CRC only for old MSP implementation
- Removed zero fill for outgoing buffer
- Some cosmetics

These changes makes it work with https://github.com/betaflight/betaflight/pull/11112 while still being compatible with the previous implementation. MSPv1 jumbo frames and MSPv2 is not implemented yet, but can be added when/if we need it. I have tested this with and without the PR, using TBS Tracer and Frsky Fport and can confirm that it works as it should. 

For testing: 
[betaflight-tx-lua-scripts_1.5.0.zip](https://github.com/betaflight/betaflight-tx-lua-scripts/files/7699926/betaflight-tx-lua-scripts_1.5.0.zip)

