### PR TITLE
Disable reboot for dynamic idle change

### DIFF
--- a/src/SCRIPTS/BF/PAGES/filters2.lua
+++ b/src/SCRIPTS/BF/PAGES/filters2.lua
@@ -46,7 +46,7 @@ return {
         self.rpmHarmonics = self.values[44]
     end,
     preSave = function(self)
-        self.reboot = self.values[44] == 0 and self.rpmHarmonics ~= 0
+        self.reboot = self.values[44] == 0 and self.rpmHarmonics ~= 0 and apiVersion <= 1.043
         return self.values
     end,
 }

--- a/src/SCRIPTS/BF/PAGES/pid_advanced.lua
+++ b/src/SCRIPTS/BF/PAGES/pid_advanced.lua
@@ -77,7 +77,7 @@ return {
         self.dynamicIdle = self.values[50]
     end,
     preSave = function(self)
-        self.reboot = self.values[50] ~= self.dynamicIdle
+        self.reboot = self.values[50] ~= self.dynamicIdle and apiVersion <= 1.043
         return self.values
     end,
 }


### PR DESCRIPTION
Previously we had to reboot for dynamic idle changes to take effect. We also had to reboot when disabling rpm filters by setting rpm harmonics to 0 because dynamic idle couldn't work without rpm filters enabled. 
After https://github.com/betaflight/betaflight/pull/11043 dynamic idle does not depend on rpm filters being enabled and the reboot isn't necessary anymore.