### PR TITLE
Fix string writes to board info table

### DIFF
--- a/src/SCRIPTS/BF/board_info.lua
+++ b/src/SCRIPTS/BF/board_info.lua
@@ -108,13 +108,13 @@ local function getBoardInfo()
     if boardInfoReceived then
         local f = io.open("BOARD_INFO/"..mcuId..".lua", 'w')
         io.write(f, "return {", "\n")
-        io.write(f, "    boardIdentifier = "..boardIdentifier..",", "\n")
+        io.write(f, "    boardIdentifier = "..'"'..boardIdentifier..'"'..",", "\n")
         io.write(f, "    hardwareRevision = "..tostring(hardwareRevision)..",", "\n")
         io.write(f, "    boardType = "..tostring(boardType)..",", "\n")
         io.write(f, "    targetCapabilities = "..tostring(targetCapabilities)..",", "\n")
-        io.write(f, "    targetName = "..targetName..",", "\n")
-        io.write(f, "    boardName = "..boardName..",", "\n")
-        io.write(f, "    manufacturerId = "..manufacturerId..",", "\n")
+        io.write(f, "    targetName = "..'"'..targetName..'"'..",", "\n")
+        io.write(f, "    boardName = "..'"'..boardName..'"'..",", "\n")
+        io.write(f, "    manufacturerId = "..'"'..manufacturerId..'"'..",", "\n")
         local signatureString = "    signature = { "
         for i = 1, #signature do
             signatureString = signatureString..tostring(signature[i])..", "


### PR DESCRIPTION
Forgot to wrap the strings with "" when writing them to file. This makes it fail on legacy targets where manufacturer id is an empty string.

Thanks @TheIsotopes for noticing and reporting this!

Test version 
[betaflight-tx-lua-scripts_1.5.0.zip](https://github.com/betaflight/betaflight-tx-lua-scripts/files/7735555/betaflight-tx-lua-scripts_1.5.0.zip)

Fixes https://github.com/betaflight/betaflight-tx-lua-scripts/issues/411