### PR TITLE
CMS periodic refresh when stick movement detected

### DIFF
--- a/src/SCRIPTS/BF/CMS/common.lua
+++ b/src/SCRIPTS/BF/CMS/common.lua
@@ -70,12 +70,14 @@ screen = {
 
 cms = {
     menuOpen = false,
+    synced = false,
     init = function(cmsConfig) 
         screen.config = assert(cmsConfig, "Resolution not supported")
         screen.reset()
         screen.clear()
         protocol.cms.close()
         cms.menuOpen = false
+        cms.synced = false
     end,
     open = function()
         protocol.cms.open(screen.config.rows, screen.config.cols)
@@ -112,6 +114,7 @@ cms = {
                     screen.buffer = cRleDecode(screen.data)
                     screen.draw()
                     screen.reset()
+                    cms.synced = true
                 end
             else
                 protocol.cms.refresh()

--- a/src/SCRIPTS/BF/cms.lua
+++ b/src/SCRIPTS/BF/cms.lua
@@ -1,16 +1,25 @@
-lastMenuEventTime = 0
+local lastMenuEventTime = 0
+local INTERVAL = 80
 
 local function init()
     cms.init(radio)
 end
 
+local function stickMovement()
+    local threshold = 30
+    return math.abs(getValue('ele')) > threshold or math.abs(getValue('ail')) > threshold or math.abs(getValue('rud')) > threshold
+end
+
 local function run(event)
-    lastMenuEventTime = getTime()
+    if stickMovement() then
+        cms.synced = false
+        lastMenuEventTime = getTime()
+    end
     cms.update()
     if (cms.menuOpen == false) then
         cms.open()
     end
-    if (event == radio.refresh.event) then
+    if (event == radio.refresh.event) or (lastMenuEventTime + INTERVAL < getTime() and not cms.synced) then
         cms.refresh()
     end
     if (event == EVT_VIRTUAL_EXIT) then


### PR DESCRIPTION
Detects stick movement and starts a periodic refresh until the menu is received. If the data is received before 800ms has passed, the periodic refresh is disabled until the sticks are moved again.
This is to avoid having to manually refresh the menu.  
