### PR TITLE
CMS move initial screen.clear() to run function

### DIFF
--- a/src/SCRIPTS/BF/CMS/common.lua
+++ b/src/SCRIPTS/BF/CMS/common.lua
@@ -74,7 +74,6 @@ cms = {
     init = function(cmsConfig) 
         screen.config = assert(cmsConfig, "Resolution not supported")
         screen.reset()
-        screen.clear()
         protocol.cms.close()
         cms.menuOpen = false
         cms.synced = false

--- a/src/SCRIPTS/BF/cms.lua
+++ b/src/SCRIPTS/BF/cms.lua
@@ -1,5 +1,6 @@
 local lastMenuEventTime = 0
 local INTERVAL = 80
+local firstRun = true
 
 local function init()
     cms.init(radio)
@@ -11,6 +12,10 @@ local function stickMovement()
 end
 
 local function run(event)
+    if firstRun then
+        screen.clear()
+        firstRun = false
+    end
     if stickMovement() then
         cms.synced = false
         lastMenuEventTime = getTime()


### PR DESCRIPTION
Adds a "first run" check to the run function that is used to clear the screen the first time the run function is executed. 
I initially added this to the init function, but it seems like lua isn't completely in control of the lcd at that point so it's possible for the screen to be cleared only for parts of the tools menu to be drawn on top of that again. 