### PR TITLE
CMS fixes

### DIFF
--- a/src/SCRIPTS/BF/cms.lua
+++ b/src/SCRIPTS/BF/cms.lua
@@ -1,6 +1,5 @@
 local lastMenuEventTime = 0
 local INTERVAL = 80
-local firstRun = true
 
 local function init()
     cms.init(radio)
@@ -12,24 +11,23 @@ local function stickMovement()
 end
 
 local function run(event)
-    if firstRun then
-        screen.clear()
-        firstRun = false
-    end
-    if stickMovement() then
-        cms.synced = false
-        lastMenuEventTime = getTime()
-    end
     cms.update()
-    if (cms.menuOpen == false) then
+    if cms.menuOpen == false then
         cms.open()
     end
-    if (event == radio.refresh.event) or (lastMenuEventTime + INTERVAL < getTime() and not cms.synced) then
-        cms.refresh()
-    end
-    if (event == EVT_VIRTUAL_EXIT) then
+    if event == radio.refresh.event then
+        cms.synced = false
+        lastMenuEventTime = 0
+    elseif stickMovement() then
+        cms.synced = false
+        lastMenuEventTime = getTime()
+    elseif event == EVT_VIRTUAL_EXIT then
         cms.close()
         return 1
+    end
+    if lastMenuEventTime + INTERVAL < getTime() and not cms.synced then
+        lastMenuEventTime = getTime()
+        cms.refresh()
     end
     return 0
 end


### PR DESCRIPTION
Various fixes for the CMS script.

- Removed double buffering for incoming data. It's not needed
- Removed some redundant tests
- Removed clearing of screen buffer so that it can be drawn multiple times
- Made some global variables local
- Fixed retry timeout reset
- Draw screen two times instead of one to avoid flickering on colour LCDs that use double buffering

 For testing
[betaflight-tx-lua-scripts_1.5.0.zip](https://github.com/betaflight/betaflight-tx-lua-scripts/files/7877901/betaflight-tx-lua-scripts_1.5.0.zip)

