### PR TITLE
Rename script in TOOLS menu

### DIFF
--- a/src/SCRIPTS/BF/vtx_tables.lua
+++ b/src/SCRIPTS/BF/vtx_tables.lua
@@ -116,4 +116,4 @@ local function getVtxTables()
     return vtxTablesReceived
 end
 
-return { f = getVtxTables, t = "Downloading VTX Tables" }
+return { f = getVtxTables, t = "Downloading VTX tables" }

--- a/src/SCRIPTS/TOOLS/bf.lua
+++ b/src/SCRIPTS/TOOLS/bf.lua
@@ -1,4 +1,4 @@
-local toolName = "TNS|Betaflight setup|TNE"
+local toolName = "TNS|Betaflight Config|TNE"
 chdir("/SCRIPTS/BF")
 
 apiVersion = 0


### PR DESCRIPTION
Rename to "Betaflight Config" to match the name in the title bar. Also fixed the downloading vtx tables string.
This change is for consistency and is purely cosmetic.
