### PR TITLE
fix shebang in bin/build.sh

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -d obj ]; then
     rm -fR obj/*


### PR DESCRIPTION
Using `env` is a more portable approach.