### PR TITLE
Check for min attribute

### DIFF
--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -122,7 +122,7 @@ local function processMspReply(cmd,rx_buf)
                         f.value = bit32.bor(f.value, raw_val)
                     end
                     local bits = #f.vals * 8
-                    if f.min < 0 and bit32.btest(f.value, bit32.lshift(1, bits - 1)) then
+                    if f.min and f.min < 0 and bit32.btest(f.value, bit32.lshift(1, bits - 1)) then
                         f.value = f.value - (2 ^ bits)
                     end
                     f.value = f.value/(f.scale or 1)


### PR DESCRIPTION
There's no guarantee that the min attribute exists for all field. vtx protocol doesn't have it. Added a check for this before comparing to avoid comparing to nil and crashing.
