### PR TITLE
Skip vtx tables download if not available

### DIFF
--- a/src/SCRIPTS/BF/PAGES/vtx.lua
+++ b/src/SCRIPTS/BF/PAGES/vtx.lua
@@ -12,8 +12,9 @@ local labels = {}
 local fields = {}
 
 local vtx_tables
-if apiVersion >= 1.42 then
-    vtx_tables = assert(loadScript("VTX_TABLES/"..mcuId..".lua"))()
+local f = loadScript("VTX_TABLES/"..mcuId..".lua")
+if apiVersion >= 1.42 and f then
+    vtx_tables = f()
 else
     vtx_tables = assert(loadScript("VTX_TABLES/vtx_defaults.lua"))()
 end

--- a/src/SCRIPTS/BF/acc_cal.lua
+++ b/src/SCRIPTS/BF/acc_cal.lua
@@ -3,8 +3,8 @@ local accCalibrated = false
 local lastRunTS = 0
 local INTERVAL = 500
 
-local function processMspReply(cmd,rx_buf)
-    if cmd == MSP_ACC_CALIBRATION then
+local function processMspReply(cmd,rx_buf,err)
+    if cmd == MSP_ACC_CALIBRATION and not err then
         accCalibrated = true
     end
 end

--- a/src/SCRIPTS/BF/api_version.lua
+++ b/src/SCRIPTS/BF/api_version.lua
@@ -4,8 +4,8 @@ local apiVersionReceived = false
 local lastRunTS = 0
 local INTERVAL = 50
 
-local function processMspReply(cmd,rx_buf)
-    if cmd == MSP_API_VERSION and #rx_buf >= 3 then
+local function processMspReply(cmd,rx_buf,err)
+    if cmd == MSP_API_VERSION and #rx_buf >= 3 and not err then
         apiVersion = rx_buf[2] + rx_buf[3] / 100
         apiVersionReceived = true
     end

--- a/src/SCRIPTS/BF/board_info.lua
+++ b/src/SCRIPTS/BF/board_info.lua
@@ -20,8 +20,8 @@ local i2cRegisteredDeviceCount = 0
 local lastRunTS = 0
 local INTERVAL = 100
 
-local function processMspReply(cmd, payload)
-    if cmd == MSP_BOARD_INFO then
+local function processMspReply(cmd, payload, err)
+    if cmd == MSP_BOARD_INFO and not err then
         local length
         local i = 1
         length = 4

--- a/src/SCRIPTS/BF/mcu_id.lua
+++ b/src/SCRIPTS/BF/mcu_id.lua
@@ -5,8 +5,8 @@ local MCUIdReceived = false
 local lastRunTS = 0
 local INTERVAL = 100
 
-local function processMspReply(cmd, payload)
-    if cmd == MSP_UID then
+local function processMspReply(cmd, payload, err)
+    if cmd == MSP_UID and not err then
         local i = 1
         local id = ""
         for j = 1, 3 do

--- a/src/SCRIPTS/BF/rssi.lua
+++ b/src/SCRIPTS/BF/rssi.lua
@@ -9,8 +9,8 @@ local rssiSource = RSSI_SOURCE_NONE
 local lastRunTS = 0
 local INTERVAL = 50
 
-local function processMspReply(cmd,rx_buf)
-    if cmd == MSP_TX_INFO and #rx_buf >= 1 then
+local function processMspReply(cmd,rx_buf,err)
+    if cmd == MSP_TX_INFO and #rx_buf >= 1 and not err then
         rssiSource = rx_buf[1]
         rssiSourceReceived = true
     end

--- a/src/SCRIPTS/BF/rtc.lua
+++ b/src/SCRIPTS/BF/rtc.lua
@@ -4,8 +4,8 @@ local timeIsSet = false
 local lastRunTS = 0
 local INTERVAL = 50
 
-local function processMspReply(cmd,rx_buf)
-    if cmd == MSP_SET_RTC then
+local function processMspReply(cmd,rx_buf,err)
+    if cmd == MSP_SET_RTC and not err then
         timeIsSet = true
     end
 end

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -96,8 +96,8 @@ local function createPopupMenu()
     end
 end
 
-local function processMspReply(cmd,rx_buf)
-    if not Page or not rx_buf then
+local function processMspReply(cmd,rx_buf,err)
+    if not Page or not rx_buf or err then
     elseif cmd == Page.write then
         if Page.eepromWrite then
             eepromWrite()

--- a/src/SCRIPTS/BF/vtx_tables.lua
+++ b/src/SCRIPTS/BF/vtx_tables.lua
@@ -2,6 +2,7 @@ local MSP_VTX_CONFIG = 88
 local MSP_VTXTABLE_BAND = 137
 local MSP_VTXTABLE_POWERLEVEL = 138
 
+local vtxAvailable = true
 local vtxTableAvailable = false
 local vtxConfigReceived = false
 local vtxFrequencyTableReceived = false
@@ -18,8 +19,12 @@ local powerTable = {}
 local lastRunTS = 0
 local INTERVAL = 100
 
-local function processMspReply(cmd, payload)
+local function processMspReply(cmd, payload, err)
     if cmd == MSP_VTX_CONFIG then
+        if err then
+            vtxAvailable = false
+            return
+        end
         vtxConfigReceived = true
         vtxTableAvailable = payload[12] ~= 0
         vtxTableConfig.bands = payload[13]
@@ -113,7 +118,7 @@ local function getVtxTables()
     end
     mspProcessTxQ()
     processMspReply(mspPollReply())
-    return vtxTablesReceived
+    return vtxTablesReceived or not vtxAvailable
 end
 
 return { f = getVtxTables, t = "Downloading VTX tables" }


### PR DESCRIPTION
Use msp error bit to determine if message is available in firmware or not. Pass msp error to the layer above so that we can take action if there's an error. 
The FC will still respond if for example MSP_VTX_CONFIG isn't available, but the msp over telemetry error bit will be set and the payload is an error code. We can use this to detect if the firmware has been compiled with VTX support, and skip vtx tables download if not.

[betaflight-tx-lua-scripts_1.7.0.zip](https://github.com/betaflight/betaflight-tx-lua-scripts/files/10951850/betaflight-tx-lua-scripts_1.7.0.zip)
