### PR TITLE
Hide VTX menu when feature is unavailable

### DIFF
--- a/src/SCRIPTS/BF/features.lua
+++ b/src/SCRIPTS/BF/features.lua
@@ -1,0 +1,5 @@
+local features = {
+    vtx = true,
+}
+
+return features

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -82,6 +82,24 @@ local function confirm(page)
     collectgarbage()
 end
 
+local function filterAvailablePages(pageFiles)
+    local newPageFiles = pageFiles
+
+    local function skipPage(script)
+        local currentPageFiles = {}
+        for i = 1, #newPageFiles do
+            if newPageFiles[i].script ~= script then
+                currentPageFiles[#currentPageFiles + 1] = newPageFiles[i]
+            end
+        end
+        newPageFiles = currentPageFiles
+    end
+
+    if not features.vtx then skipPage("vtx.lua") end
+
+    return newPageFiles
+end
+
 local function createPopupMenu()
     popupMenuActive = 1
     popupMenu = {}
@@ -296,7 +314,7 @@ local function run_ui(event)
             return 0
         end
         init = nil
-        PageFiles = assert(loadScript("pages.lua"))()
+        PageFiles = filterAvailablePages(assert(loadScript("pages.lua"))())
         invalidatePages()
         uiState = prevUiState or uiStatus.mainMenu
         prevUiState = nil

--- a/src/SCRIPTS/BF/ui_init.lua
+++ b/src/SCRIPTS/BF/ui_init.lua
@@ -22,10 +22,15 @@ local function init()
         mcuIdReceived = getMCUId.f()
         if mcuIdReceived then
             getMCUId = nil
-            local f = loadScript("VTX_TABLES/"..mcuId..".lua")
-            if f and f() then
-                vtxTablesReceived = true
-                f = nil
+            local f = loadScript("VTX_TABLES/" .. mcuId .. ".lua")
+            if f then
+                local table = f()
+                if table then
+                    vtxTablesReceived = true
+                    features.vtx = 0 < table.frequenciesPerBand
+                    f = nil
+                    table = nil
+                end
             end
             collectgarbage()
             f = loadScript("BOARD_INFO/"..mcuId..".lua")

--- a/src/SCRIPTS/BF/vtx_tables.lua
+++ b/src/SCRIPTS/BF/vtx_tables.lua
@@ -29,10 +29,12 @@ local function processMspReply(cmd, payload, err)
             vtxTableAvailable = true
             vtxFrequencyTableReceived = true
             vtxPowerTableReceived = true
+            features.vtx = false
             return
         end
         vtxConfigReceived = true
         vtxTableAvailable = payload[12] ~= 0
+        features.vtx = vtxTableAvailable
         vtxTableConfig.bands = payload[13]
         vtxTableConfig.channels = payload[14]
         vtxTableConfig.powerLevels = payload[15]

--- a/src/SCRIPTS/TOOLS/bf.lua
+++ b/src/SCRIPTS/TOOLS/bf.lua
@@ -12,6 +12,7 @@ if scriptsCompiled then
     radio = assert(loadScript("radios.lua"))().msp
     assert(loadScript(protocol.mspTransport))()
     assert(loadScript("MSP/common.lua"))()
+    features = assert(loadScript("features.lua"))()
     run = assert(loadScript("ui.lua"))()
 else
     run = assert(loadScript("COMPILE/compile.lua"))()


### PR DESCRIPTION
This is one more step in handling the absence of VTX tables, completely hiding the option in the main menu would make scrolling a tiny bit more convenient and the user won't have to wait a few seconds for no reason just to see "N/A" when clicking on VTX menu.

Also I'm not sure if this is a good solution, I was thinking about potentially being able to hide options for other features as well (e. g. some users might have no GPS or OSD and we could hide those too, or whatever optional feature may come up in the future). Hiding the VTX menu alone would require a simpler logic, hence less new lines added.