### PR TITLE
Download board info only if necessary

### DIFF
--- a/src/SCRIPTS/BF/CONFIRM/pwm.lua
+++ b/src/SCRIPTS/BF/CONFIRM/pwm.lua
@@ -1,0 +1,21 @@
+local template = assert(loadScript(radio.template))()
+local margin = template.margin
+local lineSpacing = template.lineSpacing
+local yMinLim = radio.yMinLimit
+local x = margin
+local y = yMinLim - lineSpacing
+local inc = { x = function(val) x = x + val return x end, y = function(val) y = y + val return y end }
+local labels = {}
+local fields = {}
+
+labels[#labels + 1] = { t = "Download Board Info? Press", x = x, y = inc.y(lineSpacing) }
+labels[#labels + 1] = { t = "[ENTER] to download, or",    x = x, y = inc.y(lineSpacing) }
+labels[#labels + 1] = { t = "[EXIT] to cancel.",          x = x, y = inc.y(lineSpacing) }
+fields[#fields + 1] = { x = x, y = inc.y(lineSpacing), value = "", ro = true }
+
+return {
+    title  = "Board Info",
+    labels = labels,
+    fields = fields,
+    init   = assert(loadScript("board_info.lua"))(),
+}

--- a/src/SCRIPTS/BF/PAGES/INIT/pwm.lua
+++ b/src/SCRIPTS/BF/PAGES/INIT/pwm.lua
@@ -1,0 +1,15 @@
+local function precondition()
+    if apiVersion < 1.44 then
+        -- BOARD_INFO is unavailable below 1.44
+        return nil
+    end
+    local hasBoardInfo = loadScript("BOARD_INFO/"..mcuId..".lua")
+    collectgarbage()
+    if hasBoardInfo then
+        return nil
+    else
+        return "CONFIRM/pwm.lua"
+    end
+end
+
+return precondition()

--- a/src/SCRIPTS/BF/pages.lua
+++ b/src/SCRIPTS/BF/pages.lua
@@ -37,7 +37,7 @@ if apiVersion >= 1.42 then
 end
 
 if apiVersion >= 1.16 then
-    PageFiles[#PageFiles + 1] = { title = "System / Motor", script = "pwm.lua" }
+    PageFiles[#PageFiles + 1] = { title = "System / Motor", script = "pwm.lua", init = "PAGES/INIT/pwm.lua" }
 end
 
 if apiVersion >= 1.16 then

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -94,6 +94,9 @@ local function createPopupMenu()
     if apiVersion >= 1.42 then
         popupMenu[#popupMenu + 1] = { t = "vtx tables", f = function() confirm("CONFIRM/vtx_tables.lua") end }
     end
+    if apiVersion >= 1.44 then
+        popupMenu[#popupMenu + 1] = { t = "board info", f = function() confirm("CONFIRM/pwm.lua") end }
+    end
 end
 
 local function processMspReply(cmd,rx_buf,err)

--- a/src/SCRIPTS/BF/ui_init.lua
+++ b/src/SCRIPTS/BF/ui_init.lua
@@ -1,8 +1,7 @@
 local apiVersionReceived = false
 local mcuIdReceived = false
-local boardInfoReceived = false
 local featuresReceived = false
-local getApiVersion, getMCUId, getBoardInfo, getFeaturesInfo
+local getApiVersion, getMCUId, getFeaturesInfo
 local returnTable = { f = nil, t = "" }
 
 local function init()
@@ -24,14 +23,6 @@ local function init()
             getMCUId = nil
             collectgarbage()
         end
-    elseif not boardInfoReceived and apiVersion >= 1.44 then
-        getBoardInfo = getBoardInfo or assert(loadScript("board_info.lua"))()
-        returnTable.t = getBoardInfo.t
-        boardInfoReceived = getBoardInfo.f()
-        if boardInfoReceived then
-            getBoardInfo = nil
-            collectgarbage()
-        end
     elseif not featuresReceived and apiVersion >= 1.41 then
         getFeaturesInfo = getFeaturesInfo or assert(loadScript("features_info.lua"))()
         returnTable.t = getFeaturesInfo.t
@@ -43,7 +34,7 @@ local function init()
     else
         return true
     end
-    return apiVersionReceived and vtxTablesReceived and mcuId and boardInfoReceived and featuresReceived
+    return apiVersionReceived and mcuId and featuresReceived
 end
 
 returnTable.f = init


### PR DESCRIPTION
We can postpone the downloading of the board info on script startup, because it is only used for the "System / motor" menu. This PR adds a confirmation dialog which is opened when the user selects the "System / motor" menu and the board info is not yet available. After the info has been downloaded, the user can choose to re-download the board info again from the popup menu anytime.