### PR TITLE
Add battery voltage warnings setup via LUA from radio

### DIFF
--- a/src/SCRIPTS/BF/battery_voltage.lua
+++ b/src/SCRIPTS/BF/battery_voltage.lua
@@ -1,0 +1,46 @@
+local MSP_SET_BATTERY_CONFIG = 210
+local MSP_BATTERY_CONFIG = 211
+
+local batteryConfig = {
+    warningVoltage = 0,
+    minVoltage = 0,
+    batteryType = 0
+}
+
+local function processMspReply(cmd, payload, err)
+    if cmd == MSP_BATTERY_CONFIG and not err then
+        batteryConfig.warningVoltage = payload[1]
+        batteryConfig.minVoltage = payload[2]
+        batteryConfig.batteryType = payload[3]
+    end
+end
+
+local function getBatteryConfig()
+    protocol.mspRead(MSP_BATTERY_CONFIG)
+    mspProcessTxQ()
+    processMspReply(mspPollReply())
+end
+
+local function setBatteryConfig()
+    local values = {
+        batteryConfig.warningVoltage,
+        batteryConfig.minVoltage,
+        batteryConfig.batteryType
+    }
+    protocol.mspWrite(MSP_SET_BATTERY_CONFIG, values)
+    mspProcessTxQ()
+    processMspReply(mspPollReply())
+end
+
+local function init()
+    getBatteryConfig()
+end
+
+local function run(event)
+    if event == EVT_VIRTUAL_ENTER then
+        setBatteryConfig()
+    end
+    return 0
+end
+
+return { init = init, run = run }

--- a/src/SCRIPTS/BF/pages.lua
+++ b/src/SCRIPTS/BF/pages.lua
@@ -64,4 +64,6 @@ if apiVersion >= 1.45 and features.osdSD then
     PageFiles[#PageFiles + 1] = { title = "OSD Elements", script = "pos_osd.lua" }
 end
 
+PageFiles[#PageFiles + 1] = { title = "Battery Settings", script = "battery_voltage.lua" }
+
 return PageFiles

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -97,6 +97,7 @@ local function createPopupMenu()
     if apiVersion >= 1.44 then
         popupMenu[#popupMenu + 1] = { t = "board info", f = function() confirm("CONFIRM/pwm.lua") end }
     end
+    popupMenu[#popupMenu + 1] = { t = "battery settings", f = function() confirm("battery_voltage.lua") end }
 end
 
 local function processMspReply(cmd,rx_buf,err)


### PR DESCRIPTION
Related to #505

Add battery voltage warning and minimum values configuration via LUA scripts from the radio.

* **New LUA Script**: Add `src/SCRIPTS/BF/battery_voltage.lua` to handle battery voltage warning and minimum values configuration.
  * Define functions to read and set battery voltage warning values for different battery types (Li-ion, LiPo).
  * Use MSP commands to communicate with the flight controller.
* **Pages Update**: Modify `src/SCRIPTS/BF/pages.lua` to include a new page entry for battery settings configuration.
  * Add a new page entry with the title "Battery Settings" and script "battery_voltage.lua".
* **UI Update**: Modify `src/SCRIPTS/BF/ui.lua` to include the new battery settings page in the UI menu.
  * Add the new battery settings page to the UI menu.

