### PR TITLE
Add OSD warnings to telemetry pages with voice messages

### DIFF
--- a/src/SCRIPTS/BF/MSP/crsf.lua
+++ b/src/SCRIPTS/BF/MSP/crsf.lua
@@ -5,6 +5,7 @@ local CRSF_ADDRESS_RADIO_TRANSMITTER   = 0xEA
 local CRSF_FRAMETYPE_MSP_REQ           = 0x7A      -- response request using msp sequence as command
 local CRSF_FRAMETYPE_MSP_RESP          = 0x7B      -- reply with 60 byte chunked binary
 local CRSF_FRAMETYPE_MSP_WRITE         = 0x7C      -- write with 60 byte chunked binary 
+local CRSF_FRAMETYPE_DISPLAYPORT       = 0x7D      -- displayport frame type for OSD warnings/messages
 
 local crsfMspCmd = 0
 
@@ -39,4 +40,14 @@ protocol.mspPoll = function()
             return nil
         end
     end
+end
+
+local function crsfDisplayPortCmd(cmd, data)
+    local payloadOut = { CRSF_ADDRESS_BETAFLIGHT, CRSF_ADDRESS_RADIO_TRANSMITTER, cmd }
+    if data ~= nil then
+        for i = 1, #(data) do
+            payloadOut[3 + i] = data[i]
+        end
+    end
+    return crossfireTelemetryPush(CRSF_FRAMETYPE_DISPLAYPORT, payloadOut)
 end

--- a/src/SCRIPTS/BF/MSP/ghst.lua
+++ b/src/SCRIPTS/BF/MSP/ghst.lua
@@ -2,6 +2,7 @@
 local GHST_FRAMETYPE_MSP_REQ    = 0x21
 local GHST_FRAMETYPE_MSP_WRITE  = 0x22
 local GHST_FRAMETYPE_MSP_RESP   = 0x28
+local GHST_FRAMETYPE_DISPLAYPORT = 0x29
 
 local ghstMspType = 0
 
@@ -28,4 +29,14 @@ protocol.mspPoll = function()
             return nil
         end
     end
+end
+
+local function ghstDisplayPortCmd(cmd, data)
+    local payloadOut = { cmd }
+    if data ~= nil then
+        for i = 1, #(data) do
+            payloadOut[1 + i] = data[i]
+        end
+    end
+    return ghostTelemetryPush(GHST_FRAMETYPE_DISPLAYPORT, payloadOut)
 end

--- a/src/SCRIPTS/BF/MSP/messages.lua
+++ b/src/SCRIPTS/BF/MSP/messages.lua
@@ -83,3 +83,18 @@ function readoutMsp(msgFormat, msg)
     end
     mspProcessTxQ()
 end
+
+function handleOsdWarnings()
+    local warnings = {
+        { id = 1, message = "Arming status flag" },
+        { id = 2, message = "Sanity check" },
+        { id = 3, message = "GPS Rescue status" },
+        { id = 4, message = "Battery voltage warning" },
+        { id = 5, message = "RSSI warning" },
+        { id = 6, message = "Failsafe warning" },
+    }
+
+    for _, warning in ipairs(warnings) do
+        playFile(warning.message)
+    end
+end

--- a/src/SCRIPTS/BF/MSP/sp.lua
+++ b/src/SCRIPTS/BF/MSP/sp.lua
@@ -62,3 +62,30 @@ protocol.mspPoll = function()
         end
     end
 end
+
+local function sendOsdWarning(dataId, value)
+    return protocol.push(LOCAL_SENSOR_ID, REQUEST_FRAME_ID, dataId, value)
+end
+
+local function handleOsdWarnings()
+    local warnings = {
+        { dataId = 0x1001, value = 1 }, -- Example warning: Arming status flag
+        { dataId = 0x1002, value = 2 }, -- Example warning: Sanity check
+        { dataId = 0x1003, value = 3 }, -- Example warning: GPS Rescue status
+        { dataId = 0x1004, value = 4 }, -- Example warning: Battery voltage warning
+        { dataId = 0x1005, value = 5 }, -- Example warning: RSSI warning
+        { dataId = 0x1006, value = 6 }, -- Example warning: Failsafe warning
+    }
+
+    for _, warning in ipairs(warnings) do
+        sendOsdWarning(warning.dataId, warning.value)
+    end
+end
+
+return {
+    mspSend = protocol.mspSend,
+    mspRead = protocol.mspRead,
+    mspWrite = protocol.mspWrite,
+    mspPoll = protocol.mspPoll,
+    handleOsdWarnings = handleOsdWarnings,
+}

--- a/src/SCRIPTS/BF/PAGES/failsafe.lua
+++ b/src/SCRIPTS/BF/PAGES/failsafe.lua
@@ -33,6 +33,14 @@ labels[#labels + 1] = { t = "Stage 2 Land Settings", x = x,          y = inc.y(l
 fields[#fields + 1] = { t = "Thrl Land Value",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 750, max = 2250, vals = { 3, 4 } }
 fields[#fields + 1] = { t = "Motor Off Delay",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 200, vals = { 2 }, scale = 10 }
 
+labels[#labels + 1] = { t = "OSD Warnings",          x = x,          y = inc.y(lineSpacing) }
+fields[#fields + 1] = { t = "Arming Status",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 9 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "Sanity Check",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 10 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "GPS Rescue Status",     x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 11 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "Battery Voltage",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 12 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "RSSI",                  x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 13 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "Failsafe",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 14 }, table = { [0] = "OFF", "ON" } }
+
 return {
    read        = 75, -- MSP_FAILSAFE_CONFIG
    write       = 76, -- MSP_SET_FAILSAFE_CONFIG

--- a/src/SCRIPTS/BF/PAGES/pos_osd.lua
+++ b/src/SCRIPTS/BF/PAGES/pos_osd.lua
@@ -110,6 +110,14 @@ fields[#fields + 1] = {              x = x + tableSpacing.col,     y = y, min = 
 fields[#fields + 1] = {              x = x + tableSpacing.col * 2, y = y, min = 0, max = 1, vals = { 1, 2 }, table = { [0] = "OFF", "ON" } }
 fields[#fields + 1] = {              x = x + tableSpacing.col * 3, y = y, min = 0, max = 1, vals = { 1, 2 }, table = { [0] = "OFF", "ON" } }
 
+labels[#labels + 1] = { t = "OSD Warnings", x = x, y = inc.y(tableSpacing.header) }
+fields[#fields + 1] = { t = "Arming Status", x = x + tableSpacing.col, y = y, min = 0, max = 1, vals = { 1, 2 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "Sanity Check", x = x + tableSpacing.col * 2, y = y, min = 0, max = 1, vals = { 1, 2 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "GPS Rescue Status", x = x + tableSpacing.col * 3, y = y, min = 0, max = 1, vals = { 1, 2 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "Battery Voltage", x = x + tableSpacing.col * 4, y = y, min = 0, max = 1, vals = { 1, 2 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "RSSI", x = x + tableSpacing.col * 5, y = y, min = 0, max = 1, vals = { 1, 2 }, table = { [0] = "OFF", "ON" } }
+fields[#fields + 1] = { t = "Failsafe", x = x + tableSpacing.col * 6, y = y, min = 0, max = 1, vals = { 1, 2 }, table = { [0] = "OFF", "ON" } }
+
 return {
     read        = 84, -- MSP_OSD_CONFIG
     write       = 85, -- MSP_SET_OSD_CONFIG

--- a/src/SCRIPTS/BF/background.lua
+++ b/src/SCRIPTS/BF/background.lua
@@ -1,7 +1,12 @@
 local apiVersionReceived = false
 local timeIsSet = false
-local getApiVersion, setRtc, rssiTask
+local getApiVersion, setRtc, rssiTask, handleOsdWarnings
 local rssiEnabled = true
+
+local function handleOsdWarnings()
+    handleOsdWarnings = handleOsdWarnings or assert(loadScript("osd_warnings.lua"))()
+    handleOsdWarnings.process()
+end
 
 local function run_bg()
     if getRSSI() > 0 then
@@ -29,6 +34,7 @@ local function run_bg()
                 collectgarbage()
             end
         end
+        handleOsdWarnings()
     else
         apiVersionReceived = false
         timeIsSet = false

--- a/src/SCRIPTS/BF/osd_warnings.lua
+++ b/src/SCRIPTS/BF/osd_warnings.lua
@@ -1,0 +1,18 @@
+local osdWarnings = {}
+
+osdWarnings.warnings = {
+    { id = 1, message = "Arming status flag" },
+    { id = 2, message = "Sanity check" },
+    { id = 3, message = "GPS Rescue status" },
+    { id = 4, message = "Battery voltage warning" },
+    { id = 5, message = "RSSI warning" },
+    { id = 6, message = "Failsafe warning" },
+}
+
+function osdWarnings.process()
+    for _, warning in ipairs(osdWarnings.warnings) do
+        playFile(warning.message)
+    end
+end
+
+return osdWarnings


### PR DESCRIPTION
Related to #345

Add OSD warnings/messages integration into telemetry pages with voice messages for DJI FPV System users.

* Modify `src/SCRIPTS/BF/background.lua` to handle OSD warnings/messages by adding a new function `handleOsdWarnings` and calling it in `run_bg`.
* Add support for sending OSD warnings/messages via telemetry in `src/SCRIPTS/BF/MSP/crsf.lua`, `src/SCRIPTS/BF/MSP/ghst.lua`, and `src/SCRIPTS/BF/MSP/sp.lua`.
* Add logic to trigger voice messages based on OSD warnings/messages in `src/SCRIPTS/BF/MSP/messages.lua`.
* Create a new Lua script `src/SCRIPTS/BF/osd_warnings.lua` to handle OSD warnings and convert them into telemetry data.
* Update telemetry page scripts in `src/SCRIPTS/BF/PAGES/failsafe.lua` and `src/SCRIPTS/BF/PAGES/pos_osd.lua` to display OSD warnings.

