### PR TITLE
Battery page: Fix battery capacity steps, changed max capacity to 20000

### DIFF
--- a/src/SCRIPTS/BF/PAGES/battery.lua
+++ b/src/SCRIPTS/BF/PAGES/battery.lua
@@ -17,7 +17,7 @@ fields[#fields + 1] = { t = "Maximum Cell",         x = x + indent, y = inc.y(li
 fields[#fields + 1] = { t = "Warning Cell",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 500, vals = { 12, 13 }, scale = 100 }
 
 labels[#labels + 1] = { t = "Capacity Settings",    x = x, y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Battery Capacity",     x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, steps = 25, max = 10000, vals = { 4, 5 } }
+fields[#fields + 1] = { t = "Battery Capacity",     x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, mult = 25, max = 20000, vals = { 4, 5 } }
 
 return {
    read        = 32, -- MSP_BATTERY_CONFIG


### PR DESCRIPTION
As requested in #522, this PR fixes the step value.
I also changed the max capacity to 20Ah instead of 10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the maximum value for the "Battery Capacity" field from 10,000 to 20,000.
  * Adjusted the value increment for "Battery Capacity" to use a multiplicative factor of 25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->