### PR TITLE
Update RX lua

### DIFF
--- a/src/SCRIPTS/BF/PAGES/rx.lua
+++ b/src/SCRIPTS/BF/PAGES/rx.lua
@@ -24,7 +24,7 @@ if apiVersion >= 1.47 then
     labels[#labels + 1] = { t = "Cutoffs",         x = x + indent,   y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 26 }, table = { [0] = "Auto" } }
     labels[#labels + 1] = { t = "Auto Smoothness", x = x + indent,   y = inc.y(lineSpacing) }
-    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 31 } }
+    fields[#fields + 1] = { t = "Setpoint AF",     x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 31 } }
 elseif apiVersion >= 1.44 then
     labels[#labels + 1] = { t = "RC Smoothing",    x = x,            y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Mode",            x = x + indent,   y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "ON", "OFF" } }
@@ -32,7 +32,7 @@ elseif apiVersion >= 1.44 then
     fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 26 }, table = { [0] = "Auto" } }
     fields[#fields + 1] = { t = "Feedforward",     x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 27 }, table = { [0] = "Auto" } }
     labels[#labels + 1] = { t = "Auto Smoothness", x = x + indent,   y = inc.y(lineSpacing) }
-    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 31 } }
+    fields[#fields + 1] = { t = "Setpoint AF",     x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 31 } }
 elseif apiVersion >= 1.40 then
     labels[#labels + 1] = { t = "RC Smoothing",      x = x,          y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "Interpolation", "Filter" } }

--- a/src/SCRIPTS/BF/PAGES/rx.lua
+++ b/src/SCRIPTS/BF/PAGES/rx.lua
@@ -18,26 +18,31 @@ if apiVersion >= 1.16 then
     fields[#fields + 1] = { t = "High",   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1000, max = 2000, vals = { 2, 3 } }
 end
 
-if apiVersion >= 1.44 then
+if apiVersion >= 1.47 then
+    labels[#labels + 1] = { t = "RC Smoothing",    x = x,            y = inc.y(lineSpacing) }
+    fields[#fields + 1] = { t = "Mode",            x = x + indent,   y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "ON", "OFF" } }
+    labels[#labels + 1] = { t = "Cutoffs",         x = x + indent,   y = inc.y(lineSpacing) }
+    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 26 }, table = { [0] = "Auto" } }
+    labels[#labels + 1] = { t = "Auto Smoothness", x = x + indent,   y = inc.y(lineSpacing) }
+    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 31 } }
+elseif apiVersion >= 1.44 then
     labels[#labels + 1] = { t = "RC Smoothing",    x = x,            y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Mode",            x = x + indent,   y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "ON", "OFF" } }
     labels[#labels + 1] = { t = "Cutoffs",         x = x + indent,   y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 26 }, table = { [0] = "Auto" } }
     fields[#fields + 1] = { t = "Feedforward",     x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 27 }, table = { [0] = "Auto" } }
     labels[#labels + 1] = { t = "Auto Smoothness", x = x + indent,   y = inc.y(lineSpacing) }
-    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 31 } }    
-else
-    if apiVersion >= 1.40 then
-        labels[#labels + 1] = { t = "RC Smoothing",      x = x,          y = inc.y(lineSpacing) }
-        fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "Interpolation", "Filter" } }
-        fields[#fields + 1] = { t = "Channels",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4, vals = { 24 }, table = { [0] = "RP", "RPY", "RPYT", "T", "RT" } }
-        labels[#labels + 1] = { t = "Input Filter",      x = x,          y = inc.y(lineSpacing) }
-        fields[#fields + 1] = { t = "Cutoff",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 26 }, table = { [0] = "Auto" } }
-        fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 28 }, table = { [0] = "PT1", "BIQUAD"} }
-        labels[#labels + 1] = { t = "Derivative Filter", x = x,          y = inc.y(lineSpacing) }
-        fields[#fields + 1] = { t = "Cutoff",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 27 }, table = { [0] = "Auto" } }
-        fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 29 }, table = { [0] = "Off", "PT1", "BIQUAD", "Auto"} }
-    end
+    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 31 } }
+elseif apiVersion >= 1.40 then
+    labels[#labels + 1] = { t = "RC Smoothing",      x = x,          y = inc.y(lineSpacing) }
+    fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "Interpolation", "Filter" } }
+    fields[#fields + 1] = { t = "Channels",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4, vals = { 24 }, table = { [0] = "RP", "RPY", "RPYT", "T", "RT" } }
+    labels[#labels + 1] = { t = "Input Filter",      x = x,          y = inc.y(lineSpacing) }
+    fields[#fields + 1] = { t = "Cutoff",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 26 }, table = { [0] = "Auto" } }
+    fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 28 }, table = { [0] = "PT1", "BIQUAD"} }
+    labels[#labels + 1] = { t = "Derivative Filter", x = x,          y = inc.y(lineSpacing) }
+    fields[#fields + 1] = { t = "Cutoff",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 27 }, table = { [0] = "Auto" } }
+    fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 29 }, table = { [0] = "Off", "PT1", "BIQUAD", "Auto"} }
 
     if apiVersion >= 1.20 then
         fields[#fields + 1] = { t = "Interpolation", x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 13 }, table={ [0]="Off", "Preset", "Auto", "Manual"} }

--- a/src/SCRIPTS/BF/PAGES/rx.lua
+++ b/src/SCRIPTS/BF/PAGES/rx.lua
@@ -44,7 +44,7 @@ elseif apiVersion >= 1.40 then
     fields[#fields + 1] = { t = "Cutoff",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 27 }, table = { [0] = "Auto" } }
     fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 29 }, table = { [0] = "Off", "PT1", "BIQUAD", "Auto"} }
 
-    if apiVersion >= 1.20 and apiVersion <= 1.42 then
+    if apiVersion <= 1.42 then
         fields[#fields + 1] = { t = "Interpolation", x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 13 }, table={ [0]="Off", "Preset", "Auto", "Manual"} }
         fields[#fields + 1] = { t = "Interval",      x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 50, vals = { 14 } }
     end

--- a/src/SCRIPTS/BF/PAGES/rx.lua
+++ b/src/SCRIPTS/BF/PAGES/rx.lua
@@ -44,7 +44,7 @@ elseif apiVersion >= 1.40 then
     fields[#fields + 1] = { t = "Cutoff",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 27 }, table = { [0] = "Auto" } }
     fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 29 }, table = { [0] = "Off", "PT1", "BIQUAD", "Auto"} }
 
-    if apiVersion >= 1.20 then
+    if apiVersion >= 1.20 and apiVersion <= 1.42 then
         fields[#fields + 1] = { t = "Interpolation", x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 13 }, table={ [0]="Off", "Preset", "Auto", "Manual"} }
         fields[#fields + 1] = { t = "Interval",      x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 50, vals = { 14 } }
     end

--- a/src/SCRIPTS/BF/PAGES/rx.lua
+++ b/src/SCRIPTS/BF/PAGES/rx.lua
@@ -24,7 +24,7 @@ if apiVersion >= 1.47 then
     labels[#labels + 1] = { t = "Cutoffs",         x = x + indent,   y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 26 }, table = { [0] = "Auto" } }
     labels[#labels + 1] = { t = "Auto Smoothness", x = x + indent,   y = inc.y(lineSpacing) }
-    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 31 } }
+    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 31 } }
 elseif apiVersion >= 1.44 then
     labels[#labels + 1] = { t = "RC Smoothing",    x = x,            y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Mode",            x = x + indent,   y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "ON", "OFF" } }
@@ -32,7 +32,7 @@ elseif apiVersion >= 1.44 then
     fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 26 }, table = { [0] = "Auto" } }
     fields[#fields + 1] = { t = "Feedforward",     x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 27 }, table = { [0] = "Auto" } }
     labels[#labels + 1] = { t = "Auto Smoothness", x = x + indent,   y = inc.y(lineSpacing) }
-    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 31 } }
+    fields[#fields + 1] = { t = "Setpoint",        x = x + indent*2, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 31 } }
 elseif apiVersion >= 1.40 then
     labels[#labels + 1] = { t = "RC Smoothing",      x = x,          y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "Interpolation", "Filter" } }

--- a/src/SCRIPTS/BF/PAGES/rx.lua
+++ b/src/SCRIPTS/BF/PAGES/rx.lua
@@ -18,6 +18,15 @@ if apiVersion >= 1.16 then
     fields[#fields + 1] = { t = "High",   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1000, max = 2000, vals = { 2, 3 } }
 end
 
+if apiVersion >= 1.20 and apiVersion <= 1.42 then
+    fields[#fields + 1] = { t = "Interpolation", x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 13 }, table={ [0]="Off", "Preset", "Auto", "Manual"} }
+    fields[#fields + 1] = { t = "Interval",      x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 50, vals = { 14 } }
+end
+
+if apiVersion >= 1.31 then
+    fields[#fields + 1] = { t = "Cam Angle", x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 90, vals = { 23 } }
+end
+
 if apiVersion >= 1.47 then
     labels[#labels + 1] = { t = "RC Smoothing",    x = x,            y = inc.y(lineSpacing) }
     fields[#fields + 1] = { t = "Mode",            x = x + indent,   y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 25 }, table = { [0] = "ON", "OFF" } }
@@ -44,18 +53,9 @@ elseif apiVersion >= 1.40 then
     fields[#fields + 1] = { t = "Cutoff",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 255, vals = { 27 }, table = { [0] = "Auto" } }
     fields[#fields + 1] = { t = "Type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 29 }, table = { [0] = "Off", "PT1", "BIQUAD", "Auto"} }
 
-    if apiVersion <= 1.42 then
-        fields[#fields + 1] = { t = "Interpolation", x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 3, vals = { 13 }, table={ [0]="Off", "Preset", "Auto", "Manual"} }
-        fields[#fields + 1] = { t = "Interval",      x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 50, vals = { 14 } }
-    end
-
     if apiVersion >= 1.42 then
         fields[#fields + 1] = { t = "Auto Smoothness", x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50, vals = { 31 } }
     end
-end
-
-if apiVersion >= 1.31 then
-    fields[#fields + 1] = { t = "Cam Angle", x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 90, vals = { 23 } }
 end
 
 return {


### PR DESCRIPTION
- implements https://github.com/betaflight/betaflight/pull/14411
- RC Interpolation was removed in firmware 4.3
- Change Setpoint to Setpoint AF (AutoFactor)

bytes | parameter | deprecated
-- | -- | --
1 | serial_rx_provider |
2-3 | maxcheck |
4-5 | midrc |
6-7 | mincheck |
8 | spektrum_sat_bind |
9-10 | rx_min_usec |
11-12 | rx_max_usec |
13 | rcInterpolation | 1.44
14 | rcInterpolationInterval | 1.44
15-16 | airmodeActiveThreshold |
17 | rx_spi_protocol |
18-21 | rx_spi_id |
22 | rx_spi_rf_channel_count |
23 | fpvcamAngleDegrees |
24 | rcSmoothingChannels | 1.44
25 | rc_smoothing_type | 1.44
26 | rc_smoothing_setpoint_cutoff |
27 | rc_smoothing_feedforward_cutoff | 1.47
28 | rc_smoothing_input_type | 1.44
29 | rc_smoothing_derivative_type | 1.44
30 | usbDevConfig()->type |
31 | rc_smoothing_auto_factor_rpy |
32 | rc_smoothing_mode |
33-38 | rxExpressLrsSpiConfig()->UID |
39 | rxExpressLrsSpiConfig()->modelId |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RX UI now adapts to firmware/API versions:
    - Interpolation and Interval controls limited to API 1.20–1.42.
    - Cam Angle control added for API ≥1.31.
    - RC Smoothing split into two branches:
      • API ≥1.47: new RC Smoothing block with Mode, Cutoffs, Setpoint (with Auto and Auto Smoothness) and a new Setpoint AF.  
      • API 1.44–1.46: retains older RC Smoothing fields, including Feedforward.  
    - Earlier pre-1.44 UI path has been superseded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->