### PR TITLE
Require reboot when changing battery parameters

### DIFF
--- a/src/SCRIPTS/BF/PAGES/battery.lua
+++ b/src/SCRIPTS/BF/PAGES/battery.lua
@@ -23,7 +23,7 @@ return {
    read        = 32, -- MSP_BATTERY_CONFIG
    write       = 33, -- MSP_SET_BATTERY_CONFIG
    title       = "Battery",
-   reboot      = false,
+   reboot      = true,
    eepromWrite = true,
    minBytes    = 13,
    labels      = labels,


### PR DESCRIPTION
This PR requires a reboot when changing battery parameters.

Since the GUI doesn’t trigger a reboot, I initially assumed the changes would apply without one. However, I had to unplug my drone for the new settings to take effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated battery management system reboot configuration to improve system stability and handling of power-related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->