### PR TITLE
feat: add 800x480 template

### DIFF
--- a/src/SCRIPTS/BF/TEMPLATES/800x480.lua
+++ b/src/SCRIPTS/BF/TEMPLATES/800x480.lua
@@ -1,0 +1,7 @@
+return {
+    margin       = 5,
+    indent       = 20,
+    lineSpacing  = 30,
+    listSpacing  = { line = 30, field = 200 },
+    tableSpacing = { row = 30, col = 80, header = 30 },
+}

--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -146,8 +146,8 @@ local supportedRadios =
             SaveBox = { x=300, y=180, w=220, x_offset=12, h=80, h_offset=12 },
             NoTelem = { (LCD_W-96)/2, LCD_H - 28, "No Telemetry", (COLOR_THEME_SECONDARY1 or TEXT_COLOR or 0) + INVERS + BLINK },
             textSize = 0,
-            yMinLimit = 35,
-            yMaxLimit = 280,
+            yMinLimit = 45,
+            yMaxLimit = LCD_H - 45,
         },
         cms = {
             rows = 9,

--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -1,6 +1,6 @@
 local supportedRadios =
 {
-    ["128x64"]  = 
+    ["128x64"]  =
     {
         msp = {
             template = "TEMPLATES/128x64.lua",
@@ -27,7 +27,7 @@ local supportedRadios =
             },
         },
     },
-    ["128x96"]  = 
+    ["128x96"]  =
     {
         msp = {
             template = "TEMPLATES/128x96.lua",
@@ -54,7 +54,7 @@ local supportedRadios =
             },
         },
     },
-    ["212x64"]  = 
+    ["212x64"]  =
     {
         msp = {
             template = "TEMPLATES/212x64.lua",
@@ -81,7 +81,7 @@ local supportedRadios =
             }
         },
     },
-    ["480x272"] = 
+    ["480x272"] =
     {
         msp = {
             template = "TEMPLATES/480x272.lua",
@@ -127,6 +127,34 @@ local supportedRadios =
             pixelsPerRow = 24,
             pixelsPerChar = 14,
             xIndent = 14,
+            yOffset = 32,
+            textSize = MIDSIZE,
+            refresh = {
+                event = EVT_VIRTUAL_ENTER,
+                text = "Refresh: [ENT]",
+                top = 1,
+                left = 300,
+            }
+        },
+    },
+    ["800x480"] =
+    {
+        msp = {
+            template = "TEMPLATES/800x480.lua",
+            highRes = true,
+            MenuBox = { x=300, y=180, w=220, x_offset=88, h_line=25, h_offset=6 },
+            SaveBox = { x=300, y=180, w=220, x_offset=12, h=80, h_offset=12 },
+            NoTelem = { (LCD_W-96)/2, LCD_H - 28, "No Telemetry", (COLOR_THEME_SECONDARY1 or TEXT_COLOR or 0) + INVERS + BLINK },
+            textSize = 0,
+            yMinLimit = 35,
+            yMaxLimit = 280,
+        },
+        cms = {
+            rows = 9,
+            cols = 32,
+            pixelsPerRow = 28,
+            pixelsPerChar = 25,
+            xIndent = 10,
             yOffset = 32,
             textSize = MIDSIZE,
             refresh = {

--- a/src/SCRIPTS/BF/ui.lua
+++ b/src/SCRIPTS/BF/ui.lua
@@ -1,3 +1,5 @@
+local template = assert(loadScript(radio.template))()
+
 local uiStatus =
 {
     init     = 1,
@@ -181,8 +183,8 @@ end
 
 local function drawScreenTitle(screenTitle)
     if radio.highRes then
-        lcd.drawFilledRectangle(0, 0, LCD_W, 30, COLOR_THEME_SECONDARY1 or TITLE_BGCOLOR)
-        lcd.drawText(5,5,screenTitle, COLOR_THEME_PRIMARY2 or MENU_TITLE_COLOR)
+        lcd.drawFilledRectangle(0, 0, LCD_W, template.lineSpacing + template.margin, COLOR_THEME_SECONDARY1 or TITLE_BGCOLOR)
+        lcd.drawText(template.margin,template.margin,screenTitle, COLOR_THEME_PRIMARY2 or MENU_TITLE_COLOR)
     else
         lcd.drawFilledRectangle(0, 0, LCD_W, 10, FORCE)
         lcd.drawText(1,1,screenTitle,INVERS)
@@ -217,7 +219,7 @@ local function drawScreen()
             if pageState == pageStatus.editing then
                 valueOptions = valueOptions + BLINK
             end
-        end 
+        end
         if f.value then
             if f.upd and Page.values then
                 f.upd(Page)
@@ -319,10 +321,7 @@ local function run_ui(event)
         lcd.clear()
         local yMinLim = radio.yMinLimit
         local yMaxLim = radio.yMaxLimit
-        local lineSpacing = 10
-        if radio.highRes then
-            lineSpacing = 25
-        end
+        local lineSpacing = template.lineSpacing
         local currentFieldY = (currentPage-1)*lineSpacing + yMinLim
         if currentFieldY <= yMinLim then
             mainMenuScrollY = 0


### PR DESCRIPTION
Fixes #537

Adds layout for the 800x480 resolution colour screen RadioMaster TX16 MK3. In implementing it, I realised some magic numbers were being used rather than the template values, so fixed that as well - but if wanted I can split that to a seperate PR. 

Both BF Config and BF CMS scripts have been tested on TX16S MK3 hardware. The CMS is always going to be shocking as we don't have fixed width fonts, thus trying to account for widest character makes smallest (i.e. W vs I) janky at best, and this is somewhat comparable with the 480x272 TX16S display. 

<img width="800" height="480" alt="screen-2000-01-26-182033" src="https://github.com/user-attachments/assets/8862569f-2fe1-4e7e-851e-4accdc160b5b" />
<img width="800" height="480" alt="screen-2000-01-26-183921" src="https://github.com/user-attachments/assets/e22eb57a-fdd6-4fbc-a5b2-9194efba4a21" />
<img width="800" height="480" alt="screen-2000-01-26-191242" src="https://github.com/user-attachments/assets/4c9098a7-c32d-4672-9d17-469e1a9c683d" />
<img width="800" height="480" alt="screen-2000-01-26-191247" src="https://github.com/user-attachments/assets/4f1e2303-06cd-439d-a756-92beefd9c29b" />
<img width="800" height="480" alt="screen-2000-01-26-194048" src="https://github.com/user-attachments/assets/06e1b967-6c62-4be8-971c-e6060e887fef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for 800x480 resolution displays with tailored layout templates
  * Added MSP and CMS configuration options for the new resolution, including high-resolution UI adjustments

* **Refactor**
  * UI layout now uses template-driven configuration values for consistent, flexible sizing and spacing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->