### PR TITLE
chore: add devcontainer / GitHub Codespaces support, developer documentation fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-22.04
+
+# Install toolchain dependencies at image build time for faster container startup.
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bash \
+        git \
+        lua5.2 \
+        make \
+        zip \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "betaflight-tx-lua-scripts",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "files.eol": "\n"
+      }
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,4 +10,4 @@ Please search for existing issues *before* creating new ones.
 
 # Developers
 
-Please refer to the development section in the [this folder](https://github.com/betaflight/betaflight/tree/master/docs/development).
+Please refer to the Betaflight development guidelines on the [betaflight.com development docs](https://www.betaflight.com/docs/development).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The "Betaflight setup" script lets you configure Betaflight through the MSP prot
 
 #### Saving your changes
 
-Any changes to parameters in the script will not take effect until a save is manually initiated. Change the parameters you want to change, open the function menu by long pressing [ENTER] and select "save page" to send the modified parameters back to the flight controller. 
+Any changes to parameters in the script will not take effect until a save is manually initiated. Change the parameters you want to change, open the function menu by long pressing [ENTER] and select "save page" to send the modified parameters back to the flight controller.
 
 #### Setting up VTX tables
 
@@ -86,7 +86,7 @@ Be aware that these versions are intended for testing / feedback only, and may b
 
 ## Building from source
 
-### Using a Dev Container (recommended)
+### Using a Dev Container
 
 - Open this repository in VS Code
 - Run `Dev Containers: Reopen in Container`
@@ -96,6 +96,7 @@ Be aware that these versions are intended for testing / feedback only, and may b
 
 ### Building locally
 
-- Be sure to have `make` and `luac` in version 5.2 installed in the path
+- Be sure to have `make` and Lua 5.2 (`luac`) installed in the path
+- For `make release`, you also need `git` and `zip` installed
 - Run `make` from the root folder
 - The installation files will be created in the `obj` folder. Copy the files to your transmitter as instructed in the '[Installing](#installing)' section as if you unzipped from a downloaded file.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![BF lua logo light mode](docs/assets/images/bf_lua_logo_light_mode.png#gh-light-mode-only)
 ![BF lua logo dark mode](docs/assets/images/bf_lua_logo_dark_mode.png#gh-dark-mode-only)
 
- [![Latest version](https://img.shields.io/github/v/release/betaflight/betaflight-tx-lua-scripts)](https://github.com/betaflight/betaflight-tx-lua-scripts/releases) [![Build](https://img.shields.io/github/actions/workflow/status/betaflight/betaflight-tx-lua-scripts/nightly.yml?branch=master)](https://github.com/betaflight/betaflight-tx-lua-scripts/actions/workflows/nightly.yml) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+ [![Latest version](https://img.shields.io/github/v/release/betaflight/betaflight-tx-lua-scripts)](https://github.com/betaflight/betaflight-tx-lua-scripts/releases) [![Build](https://img.shields.io/github/actions/workflow/status/betaflight/betaflight-tx-lua-scripts/nightly.yml?branch=master)](https://github.com/betaflight/betaflight-tx-lua-scripts/actions/workflows/nightly.yml) [![Open in GitHub Codespaces](https://img.shields.io/badge/Codespaces-Open-181717?logo=github)](https://codespaces.new/betaflight/betaflight-tx-lua-scripts) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 ## Requirements
 
@@ -85,6 +85,16 @@ Unstable testing versions of the latest builds of the Lua Script can be download
 Be aware that these versions are intended for testing / feedback only, and may be buggy or broken. Caution is advised when using these versions.
 
 ## Building from source
+
+### Using a Dev Container (recommended)
+
+- Open this repository in VS Code
+- Run `Dev Containers: Reopen in Container`
+- The same `.devcontainer` setup is used by GitHub Codespaces, thus you can also click the "Open in GitHub Codespaces" badge above
+- The container includes `make`, `lua`/`luac` 5.2, `zip`, `git`, and `bash`
+- Run `make` from the root folder
+
+### Building locally
 
 - Be sure to have `make` and `luac` in version 5.2 installed in the path
 - Run `make` from the root folder


### PR DESCRIPTION
For consideration

I find it  much easier to start working things like the Betaflight Lua in a devcontainer since you know it has all the dependencies and is just ready to go, regardless of your OS and setup. Plus, since GitHub Codespaces uses devcontainers, it means you can even work on it from your browser, no build environment required at all!

Additionally, the documentation omitted one or two dependencies, and there was a broken link to the development docs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Dev Container support to provide a pre-configured development environment for VS Code users with all necessary tools included.

* **Documentation**
  * Added "Open in GitHub Codespaces" badge to README header.
  * Enhanced build instructions with both Dev Container workflow and detailed local build prerequisites.
  * Updated developer documentation reference in contributing guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->