### PR TITLE
Add explicit permissions blocks for read-default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,6 +12,8 @@ jobs:
       release_build: true
 
   release:
+    permissions:
+      contents: write
     name: Release
     needs: ci
     runs-on: ubuntu-22.04

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: "30 4 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     name: 'Check and close stale issues'


### PR DESCRIPTION
The org default GITHUB_TOKEN permission is now read. Adds explicit permissions blocks so these keep the write access they rely on: stale.yaml (label/close issues and PRs) and build-release.yml (upload release assets, scoped to the release job).
