### PR TITLE
Add CMS layout for 320x240 radios

### DIFF
--- a/src/SCRIPTS/BF/radios.lua
+++ b/src/SCRIPTS/BF/radios.lua
@@ -204,7 +204,21 @@ local supportedRadios =
             yMinLimit = 30,
             yMaxLimit = 200
         },
-        cms = nil,
+        cms = {
+            rows = 13,
+            cols = 32,
+            pixelsPerRow = 16,
+            pixelsPerChar = 9,
+            xIndent = 8,
+            yOffset = 22,
+            textSize = SMLSIZE,
+            refresh = {
+                event = EVT_VIRTUAL_ENTER,
+                text = "Refresh: [ENT]",
+                top = 1,
+                left = 200,
+            }
+        },
     },
 }
 


### PR DESCRIPTION
## Add CMS layout for 320x240 radios

The `320x240` entry in `radios.lua` defines an `msp` layout but leaves `cms = nil`,
so `bfCms.lua` aborts with "Resolution not supported" on these radios. The
Betaflight setup tool works there; only the CMS tool is unavailable.

This adds a `cms` layout for that resolution, following the same structure as the
other entries.

### Sizing

These radios use EdgeTX's small font set, where `SMLSIZE` has a line height of
14px (`lv_font_en_XS`, `sml` set). With a 16px row pitch and 9px character pitch:

- width: `xIndent 8 + 32 cols * 9 = 296` of 320
- height: `yOffset 22 + 13 rows * 16 = 230` of 240

so 13 rows of 32 columns fit without overlapping glyphs, with a little margin on
both axes. The smaller font leaves room for more rows than the 480x272 profile
(9 rows), so more of the CMS page is visible at once.

### Testing

Tested on a HelloRadioSky V12 (320x240) with a Crossfire module: the CMS tool
opens, renders and navigates correctly.

I only added the resolution I could test on. `320x480` is still `cms = nil` and
would need the same treatment from someone with that hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled CMS support for the 320×240 radio display.
  * Added a 13-row, 32-column layout with display metrics.
  * Added Enter-key functionality to refresh the display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->